### PR TITLE
fix #266, fix kafka grouper conf

### DIFF
--- a/conf/kafka.conf
+++ b/conf/kafka.conf
@@ -22,7 +22,7 @@ kafka {
 
   storage.replicas = 1
 
-  grouper.factory.class = "org.apache.gearpump.streaming.transaction.lib.kafka.grouper.KafkaDefaultGrouperFactory"
+  grouper.factory.class = "org.apache.gearpump.streaming.kafka.lib.grouper.KafkaDefaultGrouperFactory"
 
   gearpump {
     streaming {

--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/KafkaConfig.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/KafkaConfig.scala
@@ -59,7 +59,8 @@ object KafkaConfig {
   // grouper config
   val GROUPER_FACTORY_CLASS = "kafka.grouper.factory.class"
 
-  def apply(): Map[String, _] = new KafkaConfig().toMap
+  def apply(): Map[String, _] = apply("kafka.conf")
+  def apply(path: String): Map[String, _] = new KafkaConfig(path).toMap
 
   implicit class ConfigToKafka(config: Map[String, _]) {
 
@@ -193,11 +194,11 @@ object KafkaConfig {
   private val LOG: Logger = LogUtil.getLogger(getClass)
 }
 
-class KafkaConfig {
+class KafkaConfig(path: String) {
   import org.apache.gearpump.streaming.kafka.lib.KafkaConfig._
 
   LOG.info("Loading Kafka configurations...")
-  val config = ConfigFactory.load("kafka.conf")
+  val config = ConfigFactory.load(path)
 
   def toMap: Map[String, _] = {
     config.entrySet.map(entry => (entry.getKey, entry.getValue.unwrapped)).toMap

--- a/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/lib/KafkaConfigSpec.scala
+++ b/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/lib/KafkaConfigSpec.scala
@@ -23,7 +23,9 @@ import org.scalatest.{Matchers, PropSpec}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.prop.PropertyChecks
 
-import java.util.{List => JList, LinkedList => JLinkedList}
+import java.util.{LinkedList => JLinkedList}
+
+import scala.util.Try
 
 class KafkaConfigSpec extends PropSpec with PropertyChecks with Matchers with MockitoSugar {
   import org.apache.gearpump.streaming.kafka.lib.KafkaConfig._
@@ -65,5 +67,26 @@ class KafkaConfigSpec extends PropSpec with PropertyChecks with Matchers with Mo
       config.getStringList(newKey, Some(defJList)) should equal (defaultValue)
       a [RuntimeException] should be thrownBy config.getStringList(newKey)
     }
+  }
+
+  property("kafka conf should be set correctly") {
+    val config = KafkaConfig()
+    assert(Try(config.getZookeeperConnect).isSuccess)
+    assert(Try(config.getConsumerTopics).isSuccess)
+    assert(Try(config.getSocketTimeoutMS).isSuccess)
+    assert(Try(config.getSocketReceiveBufferBytes).isSuccess)
+    assert(Try(config.getFetchMessageMaxBytes).isSuccess)
+    assert(Try(config.getClientId).isSuccess)
+    assert(Try(config.getConsumerEmitBatchSize).isSuccess)
+    assert(Try(config.getFetchSleepMS).isSuccess)
+    assert(Try(config.getFetchThreshold).isSuccess)
+    assert(Try(config.getProducerTopic).isSuccess)
+    assert(Try(config.getProducerEmitBatchSize).isSuccess)
+    assert(Try(config.getProducerType).isSuccess)
+    assert(Try(config.getSerializerClass).isSuccess)
+    assert(Try(config.getRequestRequiredAcks).isSuccess)
+    assert(Try(config.getMetadataBrokerList).isSuccess)
+    assert(Try(config.getGrouperFactory).isSuccess)
+    assert(Try(config.getStorageReplicas).isSuccess)
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -175,7 +175,8 @@ object Build extends sbt.Build {
           "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
           "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test",
           "org.mockito" % "mockito-core" % mockitoVersion % "test"
-        )
+        ),
+        unmanagedClasspath in Test += baseDirectory.value.getParentFile.getParentFile / "conf"
       )
   ) dependsOn (streaming % "provided")
 


### PR DESCRIPTION
1. fix kafka grouper conf
2. add ut to ensure all the configurations in `kafka.conf` is correct
3. allow setting conf path to KafkaConfig 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/267)
<!-- Reviewable:end -->
