### PR TITLE
fix #338, fix kafka leader not available exception

### DIFF
--- a/conf/kafka.conf
+++ b/conf/kafka.conf
@@ -18,6 +18,7 @@ kafka {
     producer.type = "sync"
     request.required.acks = "1"
     emit.batch.size = 100
+    fetch.metadata.timeout.ms = 10000
   }
 
   storage.replicas = 1

--- a/examples/kafka/src/test/scala/org/apache/gearpump/streaming/examples/kafka/KafkaStreamProducerSpec.scala
+++ b/examples/kafka/src/test/scala/org/apache/gearpump/streaming/examples/kafka/KafkaStreamProducerSpec.scala
@@ -101,6 +101,7 @@ class KafkaStreamProducerSpec extends PropSpec with Matchers with BeforeAndAfter
       KafkaConfig.SOCKET_TIMEOUT_MS -> "1000000",
       KafkaConfig.STORAGE_REPLICAS -> "1",
       KafkaConfig.ZOOKEEPER_CONNECT -> zookeeperConnect,
+      KafkaConfig.FETCH_METADATA_TIMEOUT_MS -> "3000",
       KafkaConfig.TIMESTAMP_FILTER_CLASS -> classOf[KafkaStreamProducerSpec.DummyFilter].getName,
       KafkaConfig.MESSAGE_DECODER_CLASS -> classOf[KafkaStreamProducerSpec.NoTimeStampDecoder].getName
     ).asJava)))

--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/KafkaConfig.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/KafkaConfig.scala
@@ -50,6 +50,7 @@ object KafkaConfig {
   val PRODUCER_TYPE = "kafka.producer.producer.type"
   val REQUEST_REQUIRED_ACKS = "kafka.producer.request.required.acks"
   val PRODUCER_EMIT_BATCH_SIZE = "kafka.producer.emit.batch.size"
+  val FETCH_METADATA_TIMEOUT_MS = "kafka.producer.fetch.metadata.timeout.ms"
 
   // storage config
   val STORAGE_REPLICAS = "kafka.storage.replicas"
@@ -137,6 +138,10 @@ class KafkaConfig(config: Config) extends Serializable  {
 
   def getRequestRequiredAcks: String = {
     getString(REQUEST_REQUIRED_ACKS)
+  }
+
+  def getFetchMetadataTimeoutMS: Int = {
+    getInt(FETCH_METADATA_TIMEOUT_MS)
   }
 
   def getMetadataBrokerList: String = {

--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/KafkaOffsetManager.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/KafkaOffsetManager.scala
@@ -36,6 +36,7 @@ object KafkaOffsetManager {
     val replicas = config.getStorageReplicas
     val zkClient = KafkaUtil.connectZookeeper(config)
     val topicExists = KafkaUtil.createTopic(zkClient, storageTopic, partitions = 1, replicas)
+    KafkaUtil.validateTopic(storageTopic, config.getMetadataBrokerList, config.getClientId, config.getFetchMetadataTimeoutMS)
     new KafkaOffsetManager(KafkaStorage(config, storageTopic, topicExists, topicAndPartition))
   }
 }

--- a/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/lib/KafkaConfigSpec.scala
+++ b/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/lib/KafkaConfigSpec.scala
@@ -43,6 +43,7 @@ class KafkaConfigSpec extends PropSpec with Matchers with MockitoSugar {
     assert(Try(config.getProducerEmitBatchSize).isSuccess)
     assert(Try(config.getProducerType).isSuccess)
     assert(Try(config.getRequestRequiredAcks).isSuccess)
+    assert(Try(config.getFetchMetadataTimeoutMS).isSuccess)
     assert(Try(config.getMetadataBrokerList).isSuccess)
     assert(Try(config.getGrouperFactory).isSuccess)
     assert(Try(config.getStorageReplicas).isSuccess)


### PR DESCRIPTION
1. check for topic exists before creating topic
2. client tries to fetch topic metadata from kafka with configurable timeout after creating topic

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/348)
<!-- Reviewable:end -->
