### PR TITLE
fix #378, construct the serializer explicitly, instead of implicitly.

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -51,13 +51,6 @@ gearpump {
   log.application.dir = "logs"
 
   serializers {
-    ## Follow this format when adding new serializer for new message types
-    ##    "org.apache.gearpump.Message" = "org.apache.gearpump.streaming.MessageSerializer"
-    "org.apache.gearpump.Message" = "org.apache.gearpump.streaming.MessageSerializer"
-    "org.apache.gearpump.streaming.task.AckRequest" = "org.apache.gearpump.streaming.AckRequestSerializer"
-    "org.apache.gearpump.streaming.task.Ack" = "org.apache.gearpump.streaming.AckSerializer"
-    "org.apache.gearpump.streaming.task.TaskId" = "org.apache.gearpump.streaming.TaskIdSerializer"
-
     ## Use default serializer for these types
     "scala.collection.immutable.List" = ""
     "scala.collection.immutable.$colon$colon" = ""
@@ -76,8 +69,6 @@ gearpump {
     "scala.Tuple4" = ""
     "scala.Tuple5" = ""
     "scala.Tuple6" = ""
-
-
   }
 
   ## How many slots each worker contains
@@ -212,7 +203,6 @@ base {
 
   akka {
     extensions = [
-      "com.romix.akka.serialization.kryo.KryoSerializationExtension$",
       "org.apache.gearpump.transport.Express$",
       "org.apache.gearpump.metrics.Metrics$"
     ]
@@ -240,17 +230,11 @@ base {
         executor = "thread-pool-executor"
         type = "PinnedDispatcher"
       }
-      serializers {
-        kryo = "com.romix.akka.serialization.kryo.KryoSerializer"
-      }
-      serialization-bindings {
-      }
-
       kryo {
         buffer-size = 4096
         classes = [
         ]
-        kryo-custom-serializer-init = "org.apache.gearpump.serializer.GearpumpSerialization"
+
         compression = off
         idstrategy = "incremental"
         implicit-registration-logging = true

--- a/core/src/main/scala/org/apache/gearpump/serializer/FastKryoSerializer.scala
+++ b/core/src/main/scala/org/apache/gearpump/serializer/FastKryoSerializer.scala
@@ -18,15 +18,16 @@
 
 package org.apache.gearpump.serializer
 
-import akka.actor.ExtendedActorSystem
-import com.romix.akka.serialization.kryo.KryoSerializer
+import akka.actor.{ExtendedActorSystem}
+import com.esotericsoftware.kryo.Kryo
+import com.romix.akka.serialization.kryo.{KryoSerializer}
+import scala.util.{Try}
 
 class FastKryoSerializer(system: ExtendedActorSystem) {
+  val config = system.settings.config
 
-  // Init kryo serialization, reading custom kryo serializer
-  GearpumpSerialization.init(system.settings.config)
-
-  private val serializer = new KryoSerializer(system).serializerPool.fetch()
+  private val serializer = new KryoSerializer(system).serializer
+  new GearpumpSerialization(config).customize(serializer.kryo)
 
   def serialize(message: AnyRef) : Array[Byte] = {
     serializer.toBinary(message)

--- a/core/src/main/scala/org/apache/gearpump/serializer/GearpumpSerialization.scala
+++ b/core/src/main/scala/org/apache/gearpump/serializer/GearpumpSerialization.scala
@@ -23,16 +23,11 @@ import com.typesafe.config.Config
 import org.apache.gearpump.util.{Constants, LogUtil}
 import org.slf4j.Logger
 
-class GearpumpSerialization {
-  val config = GearpumpSerialization.getConfig()
+class GearpumpSerialization(config: Config) {
 
   private val LOG: Logger = LogUtil.getLogger(getClass)
 
   def customize(kryo: Kryo): Unit  = {
-    customize(kryo, GearpumpSerialization.getConfig())
-  }
-
-  def customize(kryo: Kryo, config : Config): Unit  = {
 
     val serializationMap = configToMap(config, Constants.GEARPUMP_SERIALIZERS)
 
@@ -56,20 +51,5 @@ class GearpumpSerialization {
   private final def configToMap(config : Config, path: String) = {
     import scala.collection.JavaConverters._
     config.getConfig(path).root.unwrapped.asScala.toMap map { case (k, v) ⇒ k -> v.toString }
-  }
-}
-
-object GearpumpSerialization {
-
-  private var config : Config = null
-
-  def init(config : Config) = {
-    if (this.config == null) {
-      this.config = config
-    }
-  }
-
-  def getConfig() = {
-    config
   }
 }

--- a/core/src/test/scala/org/apache/gearpump/serializer/SerializerSpec.scala
+++ b/core/src/test/scala/org/apache/gearpump/serializer/SerializerSpec.scala
@@ -36,12 +36,9 @@ class SerializerSpec extends FlatSpec with Matchers with MockitoSugar {
       classOf[ClassB].getName -> classOf[ClassBSerializer].getName).asJava))
 
   "GearpumpSerialization" should "register custom serializers" in {
-
-    GearpumpSerialization.init(config)
-
-    val serialization = new GearpumpSerialization
+    val serialization = new GearpumpSerialization(config)
     val kryo = new Kryo
-    serialization.customize(kryo, config)
+    serialization.customize(kryo)
 
     val forB = kryo.getRegistration(classOf[ClassB])
     assert(forB.getSerializer.isInstanceOf[ClassBSerializer])

--- a/streaming/src/main/resources/reference.conf
+++ b/streaming/src/main/resources/reference.conf
@@ -1,0 +1,11 @@
+gearpump {
+
+  serializers {
+    ## Follow this format when adding new serializer for new message types
+    ##    "org.apache.gearpump.Message" = "org.apache.gearpump.streaming.MessageSerializer"
+    "org.apache.gearpump.Message" = "org.apache.gearpump.streaming.MessageSerializer"
+    "org.apache.gearpump.streaming.task.AckRequest" = "org.apache.gearpump.streaming.AckRequestSerializer"
+    "org.apache.gearpump.streaming.task.Ack" = "org.apache.gearpump.streaming.AckSerializer"
+    "org.apache.gearpump.streaming.task.TaskId" = "org.apache.gearpump.streaming.TaskIdSerializer"
+  }
+}

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/MessageSerializerSpec.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/MessageSerializerSpec.scala
@@ -29,9 +29,8 @@ import com.esotericsoftware.kryo.io.{Input, Output}
 class MessageSerializerSpec extends WordSpec with Matchers {
   val kryo = new Kryo
   val config = ClusterConfig.load.application
-  GearpumpSerialization.init(config)
-  val serialization = new GearpumpSerialization
-  serialization.customize(kryo, config)
+  val serialization = new GearpumpSerialization(config)
+  serialization.customize(kryo)
   val buffer = new Array[Byte](1024)
   val outPut = new Output(buffer)
   val input = new Input(buffer)


### PR DESCRIPTION
Before this fix, we don't know what config are is really used to initialize the KryoSerializer. As com.romix.akka.serialization.kryo.KryoSerializationExtension call GearpumpSerialization.custom() without passing any configuration as arguments.

After this fix, we will call GearpumpSerailization.custom(config)


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/379)
<!-- Reviewable:end -->
