### PR TITLE
fix #389, fix fetch thread bug

### DIFF
--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/FetchThread.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/FetchThread.scala
@@ -56,9 +56,9 @@ private[kafka] class FetchThread(consumers: Map[TopicAndPartition, KafkaConsumer
 
   override def run(): Unit = {
     try {
-      while (!Thread.currentThread.isInterrupted
-        && fetchMessage) {
-        if (incomingQueue.size >= fetchThreshold) {
+      while (!Thread.currentThread.isInterrupted) {
+        val hasMoreMessages = fetchMessage
+        if (!hasMoreMessages || incomingQueue.size >= fetchThreshold) {
           Thread.sleep(fetchSleepMS)
         }
       }
@@ -74,7 +74,7 @@ private[kafka] class FetchThread(consumers: Map[TopicAndPartition, KafkaConsumer
    * fetch message from each TopicAndPartition in a round-robin way
    */
   def fetchMessage: Boolean = {
-    consumers.foldLeft(false) { (hasNext, tpAndConsumer) => {
+    consumers.foldLeft(false) { (hasNext, tpAndConsumer) =>
       val (_, consumer) = tpAndConsumer
       if (incomingQueue.size < fetchThreshold) {
         if (consumer.hasNext) {
@@ -86,7 +86,6 @@ private[kafka] class FetchThread(consumers: Map[TopicAndPartition, KafkaConsumer
       } else {
         true
       }
-    }
     }
   }
 }


### PR DESCRIPTION
PR summary,

1. FetchThread sleeps rather than exits when there are no more messages
2. update KafkaStreamProducerSpec to cover the case

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/390)
<!-- Reviewable:end -->
