### PR TITLE
fix #394, fix ActorSystemBooter process not shut down after application ...

### DIFF
--- a/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/KafkaStreamProducer.scala
+++ b/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/KafkaStreamProducer.scala
@@ -53,4 +53,5 @@ class KafkaStreamProducer(taskContext : TaskContext, conf: UserConfig)
     source.pull(batchSize).foreach{msg => filter.filter(msg, startTime).map(output)}
     self ! Message("continue", System.currentTimeMillis())
   }
+
 }

--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/KafkaSource.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/KafkaSource.scala
@@ -68,6 +68,7 @@ class KafkaSource private[kafka](fetchThread: FetchThread,
         case Failure(e) => throw e
       }
     }
+    fetchThread.setDaemon(true)
     fetchThread.start()
   }
 
@@ -83,4 +84,5 @@ class KafkaSource private[kafka](fetchThread: FetchThread,
     }
     messagesBuilder.result().toList
   }
+
 }


### PR DESCRIPTION
The process is not shut down because kafka fetch thread has not been closed. This pull request adds a `close` method to `TimeReplayableSource` such that `KafkaSource` is able to close `FetchThread` at `TaskActor.onStop`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/416)
<!-- Reviewable:end -->
