### PR TITLE
fix  #423, refactor task by seperating TaskActor and Task

### DIFF
--- a/examples/complexdag/src/main/scala/org/apache/gearpump/streaming/examples/complexdag/Node.scala
+++ b/examples/complexdag/src/main/scala/org/apache/gearpump/streaming/examples/complexdag/Node.scala
@@ -18,14 +18,13 @@
 
 package org.apache.gearpump.streaming.examples.complexdag
 
-import akka.actor.Cancellable
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.{StartTime, TaskActor, TaskContext}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 
-import scala.collection.mutable
+class Node (taskContext : TaskContext, conf: UserConfig) extends Task(taskContext, conf) {
+  import taskContext.output
 
-class Node (taskContext : TaskContext, conf: UserConfig) extends TaskActor(taskContext, conf) {
   override def onStart(startTime : StartTime) : Unit = {}
 
   override def onNext(msg : Message) : Unit = {

--- a/examples/complexdag/src/main/scala/org/apache/gearpump/streaming/examples/complexdag/Sink.scala
+++ b/examples/complexdag/src/main/scala/org/apache/gearpump/streaming/examples/complexdag/Sink.scala
@@ -20,11 +20,11 @@ package org.apache.gearpump.streaming.examples.complexdag
 
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.{StartTime, TaskActor, TaskContext}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 
 import scala.collection.mutable
 
-class Sink(taskContext: TaskContext, conf: UserConfig) extends TaskActor(taskContext, conf) {
+class Sink(taskContext: TaskContext, conf: UserConfig) extends Task(taskContext, conf) {
 
   var list = mutable.MutableList[String]()
 

--- a/examples/complexdag/src/test/scala/org/apache/gearpump/streaming/examples/complexdag/DagSpec.scala
+++ b/examples/complexdag/src/test/scala/org/apache/gearpump/streaming/examples/complexdag/DagSpec.scala
@@ -19,13 +19,13 @@
 package org.apache.gearpump.streaming.examples.complexdag
 
 import org.apache.gearpump.cluster.ClientToMaster.{ShutdownApplication, SubmitApplication}
-import org.apache.gearpump.cluster.{TestUtil, MasterHarness}
 import org.apache.gearpump.cluster.MasterToClient.{ShutdownApplicationResult, SubmitApplicationResult}
+import org.apache.gearpump.cluster.{MasterHarness, TestUtil}
 import org.apache.gearpump.util.Util
-import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
 import org.scalatest.prop.PropertyChecks
+import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
 
-import scala.util.{Try, Success}
+import scala.util.{Success, Try}
 
 class DagSpec extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
 

--- a/examples/complexdag/src/test/scala/org/apache/gearpump/streaming/examples/complexdag/SourceSpec.scala
+++ b/examples/complexdag/src/test/scala/org/apache/gearpump/streaming/examples/complexdag/SourceSpec.scala
@@ -20,21 +20,27 @@ package org.apache.gearpump.streaming.examples.complexdag
 import akka.actor.ActorSystem
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.{TestUtil, UserConfig}
-import org.apache.gearpump.streaming.StreamingTestUtil
+import org.apache.gearpump.streaming.MockUtil
+import org.apache.gearpump.streaming.MockUtil._
+import org.mockito.ArgumentMatcher
+import org.mockito.Matchers._
+import org.mockito.Mockito._
 import org.scalatest.{Matchers, WordSpec}
-
-import scala.concurrent.duration._
 
 class SourceSpec extends WordSpec with Matchers {
 
   "Source" should {
     "Source should send a msg of List[String](classOf[Source].getCanonicalName)" in {
       val system1 = ActorSystem("Source", TestUtil.DEFAULT_CONFIG)
+
       val system2 = ActorSystem("Reporter", TestUtil.DEFAULT_CONFIG)
-      val (_, echo) = StreamingTestUtil.createEchoForTaskActor(classOf[Source].getName, UserConfig.empty, system1, system2)
-      echo.expectMsg(10 seconds, Message(List(classOf[Source].getCanonicalName)))
-      system1.shutdown()
-      system2.shutdown()
+
+      val context = MockUtil.mockTaskContext
+
+      val source = new Source(context, UserConfig.empty)
+      source.onNext(Message("start"))
+
+      verify(context).output(argMatch[Message](List(classOf[Source].getCanonicalName) == _.msg))
     }
   }
 }

--- a/examples/fsio/src/main/scala/org/apache/gearpump/streaming/examples/fsio/SeqFileStreamProcessor.scala
+++ b/examples/fsio/src/main/scala/org/apache/gearpump/streaming/examples/fsio/SeqFileStreamProcessor.scala
@@ -23,7 +23,7 @@ import akka.actor.Cancellable
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
 import org.apache.gearpump.streaming.examples.fsio.SeqFileStreamProcessor._
-import org.apache.gearpump.streaming.task.{StartTime, TaskActor, TaskContext}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 import org.apache.gearpump.util.HadoopConfig._
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.io.SequenceFile._
@@ -31,9 +31,9 @@ import org.apache.hadoop.io.{SequenceFile, Text}
 
 import scala.concurrent.duration.FiniteDuration
 
-class SeqFileStreamProcessor(taskContext_ : TaskContext, config: UserConfig) extends TaskActor(taskContext_, config){
+class SeqFileStreamProcessor(taskContext : TaskContext, config: UserConfig) extends Task(taskContext, config){
 
-  import taskContext._
+  import taskContext.{taskId, schedule}
 
   val outputPath = new Path(config.getString(OUTPUT_PATH).get + System.getProperty("file.separator") + taskId)
   var writer: SequenceFile.Writer = null
@@ -43,7 +43,6 @@ class SeqFileStreamProcessor(taskContext_ : TaskContext, config: UserConfig) ext
   val hadoopConf = config.hadoopConf
 
   private var msgCount : Long = 0
-  private var scheduler : Cancellable = null
   private var snapShotKVCount : Long = 0
   private var snapShotTime : Long = 0
 
@@ -53,8 +52,7 @@ class SeqFileStreamProcessor(taskContext_ : TaskContext, config: UserConfig) ext
     fs.deleteOnExit(outputPath)
     writer = SequenceFile.createWriter(hadoopConf, Writer.file(outputPath), Writer.keyClass(textClass), Writer.valueClass(textClass))
 
-    import context.dispatcher
-    scheduler = context.system.scheduler.schedule(new FiniteDuration(5, TimeUnit.SECONDS),
+    schedule(new FiniteDuration(5, TimeUnit.SECONDS),
       new FiniteDuration(5, TimeUnit.SECONDS))(reportStatus())
     snapShotTime = System.currentTimeMillis()
     LOG.info("sequence file bolt initiated")
@@ -72,7 +70,6 @@ class SeqFileStreamProcessor(taskContext_ : TaskContext, config: UserConfig) ext
 
   override def onStop(): Unit ={
     writer.close()
-    scheduler.cancel()
     LOG.info("sequence file bolt stopped")
   }
 

--- a/examples/fsio/src/main/scala/org/apache/gearpump/streaming/examples/fsio/SeqFileStreamProducer.scala
+++ b/examples/fsio/src/main/scala/org/apache/gearpump/streaming/examples/fsio/SeqFileStreamProducer.scala
@@ -20,13 +20,15 @@ package org.apache.gearpump.streaming.examples.fsio
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
 import org.apache.gearpump.streaming.examples.fsio.SeqFileStreamProducer._
-import org.apache.gearpump.streaming.task.{StartTime, TaskActor, TaskContext}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 import org.apache.gearpump.util.HadoopConfig._
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.io.SequenceFile._
 import org.apache.hadoop.io.{SequenceFile, Text}
 
-class SeqFileStreamProducer(taskContext : TaskContext, config: UserConfig) extends TaskActor(taskContext, config){
+class SeqFileStreamProducer(taskContext : TaskContext, config: UserConfig) extends Task(taskContext, config){
+
+  import taskContext.{output, self}
 
   val value = new Text()
   val key = new Text()

--- a/examples/fsio/src/main/scala/org/apache/gearpump/streaming/examples/fsio/SequenceFileIO.scala
+++ b/examples/fsio/src/main/scala/org/apache/gearpump/streaming/examples/fsio/SequenceFileIO.scala
@@ -17,15 +17,14 @@
  */
 package org.apache.gearpump.streaming.examples.fsio
 
-import com.typesafe.config.ConfigFactory
 import org.apache.gearpump.cluster.UserConfig
 import org.apache.gearpump.cluster.client.ClientContext
 import org.apache.gearpump.cluster.main.{ArgumentsParser, CLIOption, ParseResult}
 import org.apache.gearpump.partitioner.ShufflePartitioner
 import org.apache.gearpump.streaming.{AppDescription, TaskDescription}
 import org.apache.gearpump.util.Graph._
-import org.apache.gearpump.util.{Graph, LogUtil}
 import org.apache.gearpump.util.HadoopConfig._
+import org.apache.gearpump.util.{Graph, LogUtil}
 import org.apache.hadoop.conf.Configuration
 import org.slf4j.Logger
 

--- a/examples/fsio/src/test/scala/org/apache/gearpump/streaming/examples/fsio/SequenceFileIOSpec.scala
+++ b/examples/fsio/src/test/scala/org/apache/gearpump/streaming/examples/fsio/SequenceFileIOSpec.scala
@@ -19,13 +19,13 @@
 package org.apache.gearpump.streaming.examples.fsio
 
 import org.apache.gearpump.cluster.ClientToMaster.{ShutdownApplication, SubmitApplication}
-import org.apache.gearpump.cluster.{TestUtil, MasterHarness}
 import org.apache.gearpump.cluster.MasterToClient.{ShutdownApplicationResult, SubmitApplicationResult}
+import org.apache.gearpump.cluster.{MasterHarness, TestUtil}
 import org.apache.gearpump.util.Util
-import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
 import org.scalatest.prop.PropertyChecks
+import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
 
-import scala.util.{Try, Success}
+import scala.util.{Success, Try}
 
 class SequenceFileIOSpec extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
   before {

--- a/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/KafkaStreamProducer.scala
+++ b/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/KafkaStreamProducer.scala
@@ -19,26 +19,26 @@
 package org.apache.gearpump.streaming.examples.kafka
 
 import akka.actor.actorRef2Scala
-import com.twitter.bijection.Injection
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.kafka.lib.KafkaConfig
-import org.apache.gearpump.streaming.task.StartTime
 import org.apache.gearpump.streaming.kafka.KafkaSource
-import org.apache.gearpump.streaming.kafka.lib.KafkaConfig._
-import org.apache.gearpump.streaming.transaction.api.{TimeStampFilter, TimeReplayableSource, MessageDecoder}
-import org.apache.gearpump.{TimeStamp, Message}
-import org.apache.gearpump.streaming.task.{TaskActor, TaskContext}
-import scala.util.{Failure, Success}
+import org.apache.gearpump.streaming.kafka.lib.KafkaConfig
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
+import org.apache.gearpump.streaming.transaction.api.{MessageDecoder, TimeReplayableSource, TimeStampFilter}
+import org.apache.gearpump.{Message, TimeStamp}
 
 class KafkaStreamProducer(taskContext : TaskContext, conf: UserConfig)
-  extends TaskActor(taskContext, conf) {
+  extends Task(taskContext, conf) {
+
+  import taskContext.{output, self, taskId, dag}
 
   private val kafkaConfig = conf.getValue[KafkaConfig](KafkaConfig.NAME).get
   private val batchSize = kafkaConfig.getConsumerEmitBatchSize
   private val msgDecoder: MessageDecoder = kafkaConfig.getMessageDecoder
   private val filter: TimeStampFilter = kafkaConfig.getTimeStampFilter
 
-  private val source: TimeReplayableSource = new KafkaSource(taskContext.appName, taskContext,
+  val taskParallelism = dag.tasks(taskId.groupId).parallelism
+
+  private val source: TimeReplayableSource = new KafkaSource(taskContext.appName, taskId, taskParallelism,
     kafkaConfig, msgDecoder)
   private var startTime: TimeStamp = 0L
 
@@ -53,5 +53,4 @@ class KafkaStreamProducer(taskContext : TaskContext, conf: UserConfig)
     source.pull(batchSize).foreach{msg => filter.filter(msg, startTime).map(output)}
     self ! Message("continue", System.currentTimeMillis())
   }
-
 }

--- a/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/topn/Ranker.scala
+++ b/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/topn/Ranker.scala
@@ -20,10 +20,11 @@ package org.apache.gearpump.streaming.examples.kafka.topn
 
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.{StartTime, TaskActor, TaskContext}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 
-class Ranker(taskContext : TaskContext, conf: UserConfig) extends TaskActor(taskContext, conf) {
+class Ranker(taskContext : TaskContext, conf: UserConfig) extends Task(taskContext, conf) {
   import org.apache.gearpump.streaming.examples.kafka.topn.Config._
+  import taskContext.output
 
   private val windowLengthMS = getWindowLengthMS(conf)
   private val emitFrequencyMS = getEmitFrequencyMS(conf)

--- a/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/topn/RollingCount.scala
+++ b/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/topn/RollingCount.scala
@@ -20,12 +20,13 @@ package org.apache.gearpump.streaming.examples.kafka.topn
 
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.{StartTime, TaskActor, TaskContext}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 
 
-class RollingCount(taskContext : TaskContext, conf: UserConfig) extends TaskActor(taskContext, conf) {
+class RollingCount(taskContext : TaskContext, conf: UserConfig) extends Task(taskContext, conf) {
 
   import org.apache.gearpump.streaming.examples.kafka.topn.Config._
+  import taskContext.output
 
   private val windowLengthMS = getWindowLengthMS(conf)
   private val emitFrequencyMS = getEmitFrequencyMS(conf)

--- a/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/topn/RollingTopWords.scala
+++ b/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/topn/RollingTopWords.scala
@@ -18,7 +18,6 @@
 
 package org.apache.gearpump.streaming.examples.kafka.topn
 
-import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import org.apache.gearpump.cluster.UserConfig
 import org.apache.gearpump.cluster.client.ClientContext
@@ -28,7 +27,7 @@ import org.apache.gearpump.streaming.examples.kafka.KafkaStreamProducer
 import org.apache.gearpump.streaming.kafka.lib.KafkaConfig
 import org.apache.gearpump.streaming.{AppDescription, TaskDescription}
 import org.apache.gearpump.util.Graph._
-import org.apache.gearpump.util.{LogUtil, Graph}
+import org.apache.gearpump.util.{Graph, LogUtil}
 import org.slf4j.Logger
 
 object RollingTopWords extends App with ArgumentsParser {

--- a/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/wordcount/KafkaWordCount.scala
+++ b/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/wordcount/KafkaWordCount.scala
@@ -18,7 +18,6 @@
 
 package org.apache.gearpump.streaming.examples.kafka.wordcount
 
-import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
 import org.apache.gearpump.cluster.UserConfig
 import org.apache.gearpump.cluster.client.ClientContext

--- a/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/wordcount/Split.scala
+++ b/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/wordcount/Split.scala
@@ -20,9 +20,10 @@ package org.apache.gearpump.streaming.examples.kafka.wordcount
 
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.{StartTime, TaskActor, TaskContext}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 
-class Split(taskContext : TaskContext, conf: UserConfig) extends TaskActor(taskContext, conf) {
+class Split(taskContext : TaskContext, conf: UserConfig) extends Task(taskContext, conf) {
+  import taskContext.output
 
   override def onStart(startTime : StartTime) : Unit = {
   }

--- a/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/wordcount/Sum.scala
+++ b/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/wordcount/Sum.scala
@@ -20,11 +20,12 @@ package org.apache.gearpump.streaming.examples.kafka.wordcount
 
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.{StartTime, TaskActor, TaskContext}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 
 import scala.collection.mutable
 
-class Sum (taskContext : TaskContext, conf: UserConfig) extends TaskActor(taskContext, conf) {
+class Sum (taskContext : TaskContext, conf: UserConfig) extends Task(taskContext, conf) {
+  import taskContext.output
 
   private[wordcount] val map : mutable.HashMap[String, Long] = new mutable.HashMap[String, Long]()
 

--- a/examples/kafka/src/test/scala/org/apache/gearpump/streaming/examples/kafka/topn/RollingTopWordsSpec.scala
+++ b/examples/kafka/src/test/scala/org/apache/gearpump/streaming/examples/kafka/topn/RollingTopWordsSpec.scala
@@ -19,13 +19,13 @@
 package org.apache.gearpump.streaming.examples.kafka.topn
 
 import org.apache.gearpump.cluster.ClientToMaster.{ShutdownApplication, SubmitApplication}
-import org.apache.gearpump.cluster.{TestUtil, MasterHarness}
 import org.apache.gearpump.cluster.MasterToClient.{ShutdownApplicationResult, SubmitApplicationResult}
+import org.apache.gearpump.cluster.{MasterHarness, TestUtil}
 import org.apache.gearpump.util.Util
-import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
 import org.scalatest.prop.PropertyChecks
+import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
 
-import scala.util.{Try, Success}
+import scala.util.{Success, Try}
 
 class RollingTopWordsSpec extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
 

--- a/examples/kafka/src/test/scala/org/apache/gearpump/streaming/examples/kafka/wordcount/KafkaWordCountSpec.scala
+++ b/examples/kafka/src/test/scala/org/apache/gearpump/streaming/examples/kafka/wordcount/KafkaWordCountSpec.scala
@@ -19,11 +19,11 @@
 package org.apache.gearpump.streaming.examples.kafka.wordcount
 
 import org.apache.gearpump.cluster.ClientToMaster.{ShutdownApplication, SubmitApplication}
-import org.apache.gearpump.cluster.{TestUtil, MasterHarness}
 import org.apache.gearpump.cluster.MasterToClient.{ShutdownApplicationResult, SubmitApplicationResult}
+import org.apache.gearpump.cluster.{MasterHarness, TestUtil}
 import org.apache.gearpump.util.Util
-import org.scalatest.{BeforeAndAfter, PropSpec, Matchers}
 import org.scalatest.prop.PropertyChecks
+import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
 
 import scala.util.{Success, Try}
 

--- a/examples/sol/src/main/scala/org/apache/gearpump/streaming/examples/sol/SOLStreamProcessor.scala
+++ b/examples/sol/src/main/scala/org/apache/gearpump/streaming/examples/sol/SOLStreamProcessor.scala
@@ -23,11 +23,12 @@ import java.util.concurrent.TimeUnit
 import akka.actor.Cancellable
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.{StartTime, TaskActor, TaskContext}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 
 import scala.concurrent.duration.FiniteDuration
 
-class SOLStreamProcessor(taskContext : TaskContext, conf: UserConfig) extends TaskActor(taskContext, conf) {
+class SOLStreamProcessor(taskContext : TaskContext, conf: UserConfig) extends Task(taskContext, conf) {
+  import taskContext.output
 
   val taskConf = taskContext
 
@@ -37,8 +38,7 @@ class SOLStreamProcessor(taskContext : TaskContext, conf: UserConfig) extends Ta
   private var snapShotTime : Long = 0
 
   override def onStart(startTime : StartTime) : Unit = {
-    import context.dispatcher
-    scheduler = context.system.scheduler.schedule(new FiniteDuration(5, TimeUnit.SECONDS),
+    taskContext.schedule(new FiniteDuration(5, TimeUnit.SECONDS),
       new FiniteDuration(5, TimeUnit.SECONDS))(reportWordCount())
     snapShotTime = System.currentTimeMillis()
   }

--- a/examples/sol/src/main/scala/org/apache/gearpump/streaming/examples/sol/SOLStreamProducer.scala
+++ b/examples/sol/src/main/scala/org/apache/gearpump/streaming/examples/sol/SOLStreamProducer.scala
@@ -20,13 +20,13 @@ package org.apache.gearpump.streaming.examples.sol
 
 import java.util.Random
 
-import akka.serialization.SerializationExtension
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.{StartTime, TaskActor, TaskContext}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 
-class SOLStreamProducer(taskContext : TaskContext, conf: UserConfig) extends TaskActor(taskContext, conf) {
+class SOLStreamProducer(taskContext : TaskContext, conf: UserConfig) extends Task(taskContext, conf) {
   import org.apache.gearpump.streaming.examples.sol.SOLStreamProducer._
+  import taskContext.{output, self}
 
   private val sizeInBytes = conf.getInt(SOLStreamProducer.BYTES_PER_MESSAGE).get
   private var messages : Array[String] = null
@@ -36,10 +36,6 @@ class SOLStreamProducer(taskContext : TaskContext, conf: UserConfig) extends Tas
   override def onStart(startTime : StartTime) : Unit = {
     prepareRandomMessage
     self ! Start
-    val s = SerializationExtension(context.system)
-    val serializer = s.findSerializerFor("hello")
-    val serialized = serializer.toBinary("hello")
-    Console.println(s"Active serialization for string is: $serializer")
   }
 
   private def prepareRandomMessage = {

--- a/examples/sol/src/test/scala/org/apache/gearpump/streaming/examples/sol/SOLSpec.scala
+++ b/examples/sol/src/test/scala/org/apache/gearpump/streaming/examples/sol/SOLSpec.scala
@@ -19,13 +19,13 @@
 package org.apache.gearpump.streaming.examples.sol
 
 import org.apache.gearpump.cluster.ClientToMaster.{ShutdownApplication, SubmitApplication}
-import org.apache.gearpump.cluster.{TestUtil, MasterHarness}
 import org.apache.gearpump.cluster.MasterToClient.{ShutdownApplicationResult, SubmitApplicationResult}
+import org.apache.gearpump.cluster.{MasterHarness, TestUtil}
 import org.apache.gearpump.util.Util
-import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
 import org.scalatest.prop.PropertyChecks
+import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
 
-import scala.util.{Try, Success}
+import scala.util.{Success, Try}
 
 class SOLSpec extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
   before {

--- a/examples/sol/src/test/scala/org/apache/gearpump/streaming/examples/sol/SOLStreamProducerSpec.scala
+++ b/examples/sol/src/test/scala/org/apache/gearpump/streaming/examples/sol/SOLStreamProducerSpec.scala
@@ -17,23 +17,26 @@
  */
 package org.apache.gearpump.streaming.examples.sol
 
-import akka.actor.ActorSystem
 import org.apache.gearpump.Message
-import org.apache.gearpump.cluster.{UserConfig, TestUtil}
-import org.apache.gearpump.streaming.StreamingTestUtil
-import org.scalatest.{WordSpec, Matchers}
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.MockUtil
+import org.apache.gearpump.streaming.task.StartTime
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest.{Matchers, WordSpec}
 
 class SOLStreamProducerSpec extends WordSpec with Matchers {
 
   "SOLStreamProducer" should {
     "producer message continuously" in {
-      val system1 = ActorSystem("SOLStreamProducer", TestUtil.DEFAULT_CONFIG)
-      val system2 = ActorSystem("Reporter", TestUtil.DEFAULT_CONFIG)
+
       val conf = UserConfig.empty.withInt(SOLStreamProducer.BYTES_PER_MESSAGE, 100)
-      val (_, echo) = StreamingTestUtil.createEchoForTaskActor(classOf[SOLStreamProducer].getName, conf, system1, system2, usePinedDispatcherForTaskActor = true)
-      echo.expectMsgAllClassOf(classOf[Message])
-      system1.shutdown()
-      system2.shutdown()
+      val context = MockUtil.mockTaskContext
+
+      val producer = new SOLStreamProducer(context, conf)
+      producer.onStart(StartTime(0))
+      producer.onNext(Message("msg"))
+      verify(context).output(any[Message])
     }
   }
 }

--- a/examples/wordcount/src/main/scala/org/apache/gearpump/streaming/examples/wordcount/Split.scala
+++ b/examples/wordcount/src/main/scala/org/apache/gearpump/streaming/examples/wordcount/Split.scala
@@ -20,9 +20,10 @@ package org.apache.gearpump.streaming.examples.wordcount
 
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.{StartTime, TaskActor, TaskContext}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 
-class Split(taskContext : TaskContext, conf: UserConfig) extends TaskActor(taskContext, conf) {
+class Split(taskContext : TaskContext, conf: UserConfig) extends Task(taskContext, conf) {
+  import taskContext.{output, self}
 
   override def onStart(startTime : StartTime) : Unit = {
     self ! Message("start")
@@ -30,7 +31,7 @@ class Split(taskContext : TaskContext, conf: UserConfig) extends TaskActor(taskC
 
   override def onNext(msg : Message) : Unit = {
     Split.TEXT_TO_SPLIT.lines.foreach { line =>
-      line.split(" ").foreach { msg =>
+      line.split("[\\s]+").filter(_.nonEmpty).foreach { msg =>
         output(new Message(msg, System.currentTimeMillis()))
       }
     }

--- a/examples/wordcount/src/main/scala/org/apache/gearpump/streaming/examples/wordcount/Sum.scala
+++ b/examples/wordcount/src/main/scala/org/apache/gearpump/streaming/examples/wordcount/Sum.scala
@@ -23,12 +23,12 @@ import java.util.concurrent.TimeUnit
 import akka.actor.Cancellable
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.{StartTime, TaskActor, TaskContext}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 
 import scala.collection.mutable
 import scala.concurrent.duration.FiniteDuration
 
-class Sum (taskContext : TaskContext, conf: UserConfig) extends TaskActor(taskContext, conf) {
+class Sum (taskContext : TaskContext, conf: UserConfig) extends Task(taskContext, conf) {
   private[wordcount] val map : mutable.HashMap[String, Long] = new mutable.HashMap[String, Long]()
 
   private[wordcount] var wordCount : Long = 0
@@ -38,8 +38,7 @@ class Sum (taskContext : TaskContext, conf: UserConfig) extends TaskActor(taskCo
   private var scheduler : Cancellable = null
 
   override def onStart(startTime : StartTime) : Unit = {
-    import context.dispatcher
-    scheduler = context.system.scheduler.schedule(new FiniteDuration(5, TimeUnit.SECONDS),
+    taskContext.schedule(new FiniteDuration(5, TimeUnit.SECONDS),
       new FiniteDuration(5, TimeUnit.SECONDS))(reportWordCount)
   }
 

--- a/examples/wordcount/src/test/scala/org/apache/gearpump/streaming/examples/wordcount/WordCountSpec.scala
+++ b/examples/wordcount/src/test/scala/org/apache/gearpump/streaming/examples/wordcount/WordCountSpec.scala
@@ -19,13 +19,13 @@
 package org.apache.gearpump.streaming.examples.wordcount
 
 import org.apache.gearpump.cluster.ClientToMaster.{ShutdownApplication, SubmitApplication}
-import org.apache.gearpump.cluster.{TestUtil, MasterHarness}
 import org.apache.gearpump.cluster.MasterToClient.{ShutdownApplicationResult, SubmitApplicationResult}
+import org.apache.gearpump.cluster.{MasterHarness, TestUtil}
 import org.apache.gearpump.util.Util
-import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
 import org.scalatest.prop.PropertyChecks
+import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
 
-import scala.util.{Try, Success}
+import scala.util.{Success, Try}
 
 class WordCountSpec extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
 

--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/KafkaSource.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/KafkaSource.scala
@@ -20,7 +20,7 @@ package org.apache.gearpump.streaming.kafka
 
 import kafka.common.TopicAndPartition
 import org.apache.gearpump.streaming.kafka.lib.grouper.KafkaGrouper
-import org.apache.gearpump.streaming.task.TaskContext
+import org.apache.gearpump.streaming.task.{TaskId}
 import org.apache.gearpump.streaming.kafka.lib._
 import org.apache.gearpump.streaming.transaction.api.OffsetStorage.StorageEmpty
 import org.apache.gearpump.streaming.transaction.api._
@@ -49,8 +49,8 @@ class KafkaSource private[kafka](fetchThread: FetchThread,
     this(appName, config, KafkaUtil.getTopicAndPartitions(KafkaUtil.connectZookeeper(config),
       grouper, config.getConsumerTopics), messageDecoder)
 
-  def this(appName : String, taskContext : TaskContext, config: KafkaConfig, messageDecoder: MessageDecoder) =
-    this(appName: String, config, config.getGrouperFactory.getKafkaGrouper(taskContext), messageDecoder)
+  def this(appName : String, taskId: TaskId, taskParallelism:Int, config: KafkaConfig, messageDecoder: MessageDecoder) =
+    this(appName: String, config, config.getGrouperFactory.getKafkaGrouper(taskId, taskParallelism), messageDecoder)
 
   private var startTime: TimeStamp = 0L
 

--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/grouper/KafkaDefaultGrouper.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/grouper/KafkaDefaultGrouper.scala
@@ -20,13 +20,11 @@ package org.apache.gearpump.streaming.kafka.lib.grouper
 
 import kafka.common.TopicAndPartition
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.TaskContext
+import org.apache.gearpump.streaming.task.{TaskId, TaskContext, TaskContextData}
 
 class KafkaDefaultGrouperFactory extends KafkaGrouperFactory {
-  override def getKafkaGrouper(conf: TaskContext): KafkaGrouper = {
-    val taskNum = conf.dag.tasks(conf.taskId.groupId).parallelism
-    val taskIndex = conf.taskId.index
-    new KafkaDefaultGrouper(taskNum, taskIndex)
+  override def getKafkaGrouper(taskId: TaskId, taskParallelism:Int): KafkaGrouper = {
+    new KafkaDefaultGrouper(taskParallelism, taskId.index)
   }
 }
 

--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/grouper/KafkaGrouper.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/grouper/KafkaGrouper.scala
@@ -20,10 +20,10 @@ package org.apache.gearpump.streaming.kafka.lib.grouper
 
 import kafka.common.TopicAndPartition
 import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.TaskContext
+import org.apache.gearpump.streaming.task.{TaskId, TaskContext, TaskContextData}
 
 trait KafkaGrouperFactory {
-  def getKafkaGrouper(conf: TaskContext): KafkaGrouper
+  def getKafkaGrouper(taskId: TaskId, taskParallelism:Int): KafkaGrouper
 }
 
 trait KafkaGrouper {

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/ClusterMessage.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/ClusterMessage.scala
@@ -21,12 +21,12 @@ package org.apache.gearpump.streaming
 import akka.actor.{Actor, ActorRef}
 import org.apache.gearpump.TimeStamp
 import org.apache.gearpump.cluster.scheduler.Resource
-import org.apache.gearpump.streaming.task.{TaskContext, TaskId}
+import org.apache.gearpump.streaming.task.{TaskActor, Task, TaskContextData, TaskId}
 import org.apache.gearpump.transport.HostPort
 import scala.language.existentials
 
 object AppMasterToExecutor {
-  case class LaunchTask(taskId: TaskId, taskContext: TaskContext, taskClass: Class[_ <: Actor])
+  case class LaunchTask(taskId: TaskId, taskContext: TaskContextData, taskClass: Class[_ <: Task], taskActorClass: Class[_ <: Actor] = classOf[TaskActor])
 
   case class StartClock(clock : TimeStamp)
   case object RestartClockService

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/ExecutorManager.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/ExecutorManager.scala
@@ -26,7 +26,8 @@ import org.apache.gearpump.cluster.scheduler.{Resource, ResourceRequest}
 import org.apache.gearpump.cluster.{AppMasterContext, ClusterConfigSource, ExecutorContext, UserConfig}
 import org.apache.gearpump.streaming.ExecutorToAppMaster.RegisterExecutor
 import org.apache.gearpump.streaming.appmaster.ExecutorManager._
-import org.apache.gearpump.streaming.{AppDescription, Executor}
+import org.apache.gearpump.streaming.AppDescription
+import org.apache.gearpump.streaming.executor.Executor
 import org.apache.gearpump.util.{LogUtil, Util}
 
 import scala.util.Try

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/task/ExpressTransport.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/task/ExpressTransport.scala
@@ -32,7 +32,7 @@ trait ExpressTransport {
   implicit val system = context.system.asInstanceOf[ExtendedActorSystem]
   final val serializer = new FastKryoSerializer(system)
   final def local = express.localHost
-  lazy val sourceId = TaskId.toLong(taskContext.taskId)
+  lazy val sourceId = TaskId.toLong(taskContextData.taskId)
 
   val sendLater = new SendLater(express, serializer, self)
 

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/task/StartTime.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/task/StartTime.scala
@@ -2,4 +2,4 @@ package org.apache.gearpump.streaming.task
 
 import org.apache.gearpump.TimeStamp
 
-class StartTime(val startTime : TimeStamp = 0)
+case class StartTime(val startTime : TimeStamp = 0)

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskContextData.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskContextData.scala
@@ -21,5 +21,5 @@ package org.apache.gearpump.streaming.task
 import akka.actor.ActorRef
 import org.apache.gearpump.streaming.DAG
 
-case class TaskContext(taskId : TaskId, executorId : Int, appId : Int, appName : String,
-                      appMaster : ActorRef, parallelism: Int, dag : DAG)
+case class TaskContextData(taskId : TaskId, executorId : Int, appId : Int,
+                      appName: String, appMaster : ActorRef, parallelism: Int, dag : DAG)

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskUtil.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskUtil.scala
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,24 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+ 
+package org.apache.gearpump.streaming.task
 
-package org.apache.gearpump.streaming.examples.complexdag
+import akka.actor.Actor
 
-import org.apache.gearpump.Message
-import org.apache.gearpump.cluster.UserConfig
-import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
+object TaskUtil {
 
-class Source(taskContext: TaskContext, conf: UserConfig) extends Task(taskContext, conf) {
-  import taskContext.{output, self}
-
-  override def onStart(startTime: StartTime): Unit = {
-    self ! Message("start")
-  }
-
-  override def onNext(msg: Message): Unit = {
-    val list = List(getClass.getCanonicalName)
-    output(new Message(list, System.currentTimeMillis))
-    self ! Message("continue", System.currentTimeMillis())
+  /**
+   * Resolve a classname to a Task class.
+   * @param className
+   * @return
+   */
+  def loadClass(className: String): Class[_<:Task] = {
+    Class.forName(className).asSubclass(classOf[Task])
   }
 }
-

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskWrapper.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskWrapper.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+package org.apache.gearpump.streaming.task
+
+import akka.actor.{ActorSystem, Cancellable, Props, ActorRef}
+import org.apache.gearpump.Message
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.DAG
+import org.apache.gearpump.util.LogUtil
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * This provides TaskContext for user defined tasks
+ * @param taskClass
+ * @param context
+ * @param userConf
+ */
+class TaskWrapper(taskClass: Class[_ <: Task], context: TaskContextData, userConf: UserConfig) extends TaskContext with TaskInterface {
+
+  private val LOG = LogUtil.getLogger(getClass)
+
+  private var actor: TaskActor = null
+
+  private var task: Task = null
+
+  def setTaskActor(actor: TaskActor): Unit = this.actor = actor
+
+  override def taskId: TaskId = context.taskId
+
+  override def appId: Int = context.appId
+
+  override def appName: String = context.appName
+
+  override def executorId: Int = context.executorId
+
+  override def parallelism: Int = context.parallelism
+
+  override def appMaster: ActorRef = context.appMaster
+
+  override def dag: DAG = context.dag
+
+  override def output(msg: Message): Unit = actor.output(msg)
+
+  def self: ActorRef = actor.context.self
+
+  def system: ActorSystem = actor.context.system
+
+  /**
+   * @see ActorRefProvider.actorOf
+   */
+  override def actorOf(props: Props): ActorRef = actor.context.actorOf(props)
+
+  /**
+   * @see ActorRefProvider.actorOf
+   */
+  override def actorOf(props: Props, name: String): ActorRef = actor.context.actorOf(props, name)
+
+  override def onStart(startTime: StartTime): Unit = {
+    if (null != task) {
+      LOG.error("Task.onStart should not be called multiple times...")
+    }
+    val constructor = taskClass.getConstructor(classOf[TaskContext], classOf[UserConfig])
+    task = constructor.newInstance(this, userConf)
+    task.onStart(startTime)
+  }
+
+  override def onNext(msg: Message): Unit = task.onNext(msg)
+
+  override def onStop(): Unit = {
+    task.onStop()
+    task = null
+  }
+
+  def schedule(initialDelay: FiniteDuration, interval: FiniteDuration)(f: ⇒ Unit): Cancellable = {
+    val dispatcher = actor.context.system.dispatcher
+    actor.context.system.scheduler.schedule(initialDelay, interval)(f)(dispatcher)
+  }
+}

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/MockUtil.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/MockUtil.scala
@@ -15,26 +15,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.gearpump.streaming.examples.kafka.wordcount
+package org.apache.gearpump.streaming
 
+import akka.actor.{ActorSystem, Actor, ActorRef, ScalaActorRef}
+import akka.testkit.TestActorRef
 import org.apache.gearpump.Message
-import org.apache.gearpump.cluster.UserConfig
 import org.apache.gearpump.streaming.task.TaskContext
-import org.mockito.Matchers._
-import org.mockito.Mockito._
-import org.scalatest._
-import org.scalatest.mock.MockitoSugar
+import org.mockito.{Mockito, ArgumentMatcher}
+import org.mockito.Mockito
+import org.mockito.Matchers
 
-import scala.language.postfixOps
+object MockUtil {
 
-class SplitSpec extends FlatSpec with Matchers with MockitoSugar {
+  lazy val system: ActorSystem = ActorSystem("mockUtil")
 
-  it should "split should split the text and deliver to next task" in {
-    val taskContext = mock[TaskContext]
-    val split = new Split(taskContext, UserConfig.empty)
+  def mockTaskContext: TaskContext = {
+    val context = Mockito.mock(classOf[TaskContext])
+    Mockito.when(context.self).thenReturn(Mockito.mock(classOf[TestActorRef[Actor]]))
+    Mockito.when(context.system).thenReturn(system)
+    context
+  }
 
-    val msg = "this is a test message"
-    split.onNext(Message(msg))
-    verify(taskContext, times(msg.split(" ").length)).output(anyObject[Message])
+  def argMatch[T](func: T => Boolean) : T = {
+    Matchers.argThat(new ArgumentMatcher[T] {
+      override def matches(param: Any): Boolean = {
+        val mesage = param.asInstanceOf[T]
+        func(mesage)
+      }
+    })
   }
 }

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/AppMasterSpec.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/AppMasterSpec.scala
@@ -48,8 +48,8 @@ class AppMasterSpec extends WordSpec with Matchers with BeforeAndAfterEach with 
   val appId = 0
   val workerId = 1
   val resource = Resource(1)
-  val taskDescription1 = TaskDescription(classOf[TaskActorA].getName, 2)
-  val taskDescription2 = TaskDescription(classOf[TaskActorB].getName, 2)
+  val taskDescription1 = TaskDescription(classOf[TaskA].getName, 2)
+  val taskDescription2 = TaskDescription(classOf[TaskB].getName, 2)
   var conf: UserConfig = null
 
   var mockTask: TestProbe = null
@@ -90,7 +90,6 @@ class AppMasterSpec extends WordSpec with Matchers with BeforeAndAfterEach with 
     mockMaster.expectMsg(GetAppData(appId, "startClock"))
     mockMaster.reply(GetAppDataResult("startClock", 0L))
     mockMaster.expectMsg(RequestResource(appId, ResourceRequest(Resource(4))))
-    Thread.sleep(1000)
   }
 
   override def afterEach() = {
@@ -171,7 +170,7 @@ object AppMasterSpec {
   val MOCK_MASTER_PROXY = "mockMasterProxy"
 }
 
-class TaskActorA(taskContext : TaskContext, userConf : UserConfig) extends TaskActor(taskContext, userConf) {
+class TaskA(taskContext : TaskContext, userConf : UserConfig) extends Task(taskContext, userConf) {
 
   val master = userConf.getValue[ActorRef](AppMasterSpec.MASTER).get
   override def onStart(startTime: StartTime): Unit = {
@@ -181,7 +180,7 @@ class TaskActorA(taskContext : TaskContext, userConf : UserConfig) extends TaskA
   override def onNext(msg: Message): Unit = {}
 }
 
-class TaskActorB(taskContext : TaskContext, userConf : UserConfig) extends TaskActor(taskContext, userConf) {
+class TaskB(taskContext : TaskContext, userConf : UserConfig) extends Task(taskContext, userConf) {
 
   val master = userConf.getValue[ActorRef](AppMasterSpec.MASTER).get
   override def onStart(startTime: StartTime): Unit = {

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/TaskLocatorSpec.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/TaskLocatorSpec.scala
@@ -17,11 +17,11 @@
  */
 package org.apache.gearpump.streaming.appmaster
 
-import akka.actor.Actor
-import org.apache.gearpump.cluster.ClusterConfig
-import org.apache.gearpump.streaming.appmaster.TaskLocator
+import org.apache.gearpump.Message
+import org.apache.gearpump.cluster.{ClusterConfig, UserConfig}
+import org.apache.gearpump.streaming.TaskDescription
 import org.apache.gearpump.streaming.appmaster.TaskLocator.{NonLocality, WorkerLocality}
-import org.apache.gearpump.streaming.{TaskDescription}
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 import org.apache.gearpump.util.Constants._
 import org.scalatest.{Matchers, WordSpec}
 
@@ -57,14 +57,20 @@ class TaskLocatorSpec extends WordSpec with Matchers {
   }
 }
 
-class TestTask1 extends Actor {
-  override def receive: Actor.Receive = null
+class TestTask1(taskContext : TaskContext, userConf : UserConfig)
+    extends Task(taskContext, userConf) {
+  override def onStart(startTime: StartTime): Unit = ???
+  override def onNext(msg: Message): Unit = ???
 }
 
-class TestTask2 extends Actor {
-  override def receive: Receive = null
+class TestTask2(taskContext : TaskContext, userConf : UserConfig)
+    extends Task(taskContext, userConf) {
+  override def onStart(startTime: StartTime): Unit = ???
+  override def onNext(msg: Message): Unit = ???
 }
 
-class TestTask3 extends Actor {
-  override def receive: Receive = null
+class TestTask3(taskContext : TaskContext, userConf : UserConfig)
+    extends Task(taskContext, userConf) {
+  override def onStart(startTime: StartTime): Unit = ???
+  override def onNext(msg: Message): Unit = ???
 }

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/executor/ExecutorSpec.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/executor/ExecutorSpec.scala
@@ -1,35 +1,36 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package org.apache.gearpump.streaming.executor
 
 import akka.actor.{Actor, ActorRef, PoisonPill, Props}
 import akka.testkit._
 import com.typesafe.config.ConfigFactory
+import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.MasterToAppMaster.ReplayFromTimestampWindowTrailingEdge
 import org.apache.gearpump.cluster.scheduler.Resource
 import org.apache.gearpump.cluster.{ExecutorContext, MasterHarness, TestUtil, UserConfig}
 import org.apache.gearpump.streaming.AppMasterToExecutor._
-import org.apache.gearpump.streaming.Executor.RestartExecutor
+import Executor.{TaskLocationReady, RestartExecutor}
 import org.apache.gearpump.streaming.ExecutorToAppMaster.RegisterExecutor
-import org.apache.gearpump.streaming.executor.ExecutorSpec.{MsgLost, MockTaskStarted, MockTask}
+import org.apache.gearpump.streaming.executor.ExecutorSpec.{MockTask, MockTaskActor, MockTaskStarted, MsgLost}
 import org.apache.gearpump.streaming.task.TaskActor.RestartTask
-import org.apache.gearpump.streaming.task.{TaskContext, TaskId, TaskLocations}
-import org.apache.gearpump.streaming.{DAG, Executor, TaskLocationReady}
+import org.apache.gearpump.streaming.task._
+import org.apache.gearpump.streaming.{DAG}
 import org.apache.gearpump.transport.HostPort
 import org.scalatest._
 
@@ -49,7 +50,7 @@ class ExecutorSpec extends WordSpec with Matchers with BeforeAndAfterEach with M
   var appMaster: TestProbe = null
   var executor: TestActorRef[Executor] = null
   var executorContext: ExecutorContext = null
-  var taskContext: TaskContext = null
+  var taskContext: TaskContextData = null
   var task: TestProbe = null
 
   override def beforeEach() = {
@@ -60,7 +61,7 @@ class ExecutorSpec extends WordSpec with Matchers with BeforeAndAfterEach with M
     task = TestProbe()
     val userConfig = UserConfig.empty.withValue(ExecutorSpec.TASK_PROBE, task.ref)
     executorContext = ExecutorContext(executorId, workerId, appId, appMaster.ref, resource)
-    taskContext = TaskContext(TaskId(0, 0), executorId, appId, "appName", appMaster.ref, 1, DAG.empty())
+    taskContext = TaskContextData(TaskId(0, 0), executorId, appId, "appName", appMaster.ref, 1, DAG.empty())
     executor = TestActorRef(Props(classOf[Executor], executorContext, userConfig))(getActorSystem)
     appMaster.expectMsg(RegisterExecutor(executor, executorId, resource, workerId))
   }
@@ -71,7 +72,7 @@ class ExecutorSpec extends WordSpec with Matchers with BeforeAndAfterEach with M
 
   "The new started executor" should {
     "launch task properly" in {
-      executor.tell(LaunchTask(TaskId(0, 0), taskContext, classOf[MockTask]), watcher.ref)
+      executor.tell(LaunchTask(TaskId(0, 0), taskContext, classOf[MockTask], classOf[MockTaskActor]), watcher.ref)
       task.expectMsg(MockTaskStarted)
       val locations = TaskLocations(Map.empty[HostPort, Set[TaskId]])
       executor.tell(locations, watcher.ref)
@@ -89,7 +90,7 @@ class ExecutorSpec extends WordSpec with Matchers with BeforeAndAfterEach with M
 
     "handle exception thrown from child properly" in {
       implicit val system = getActorSystem
-      executor.tell(LaunchTask(TaskId(0, 0), taskContext, classOf[MockTask]), watcher.ref)
+      executor.tell(LaunchTask(TaskId(0, 0), taskContext,classOf[MockTask] ,classOf[MockTaskActor]), watcher.ref)
       task.expectMsg(MockTaskStarted)
       EventFilter[MsgLostException](occurrences = 1) intercept {
         executor.children.head ! MsgLost
@@ -114,7 +115,7 @@ object ExecutorSpec {
   case object MsgLost
 
 
-  class MockTask(taskContext : TaskContext, userConf : UserConfig) extends Actor {
+  class MockTaskActor(taskContext : TaskContextData, userConf : UserConfig, task: TaskWrapper) extends Actor {
     implicit val system = context.system
     val taskProbe = userConf.getValue[ActorRef](TASK_PROBE).get
 
@@ -131,5 +132,12 @@ object ExecutorSpec {
         taskProbe forward msg
     }
   }
+
+  class MockTask(taskContext : TaskContext, userConf : UserConfig) extends Task(taskContext, userConf) {
+    override def onStart(startTime: StartTime): Unit = Unit
+
+    override def onNext(msg: Message): Unit = Unit
+  }
 }
+
 

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/task/TaskActorSpec.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/task/TaskActorSpec.scala
@@ -1,20 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 package org.apache.gearpump.streaming.task
 
 import akka.actor.{Actor, ActorRef, Props, ActorSystem}
@@ -26,11 +26,13 @@ import org.apache.gearpump.partitioner.HashPartitioner
 import org.apache.gearpump.streaming.AppMasterToExecutor.{MsgLostException, RestartException, StartClock}
 import org.apache.gearpump.streaming.ExecutorToAppMaster.{RegisterExecutor, RegisterTask}
 import org.apache.gearpump.streaming.task.TaskActor.RestartTask
-import org.apache.gearpump.streaming.{Executor, StreamingTestUtil, DAG, TaskDescription}
+import org.apache.gearpump.streaming.task.TaskActorSpec.TestTask
+import org.apache.gearpump.streaming.{StreamingTestUtil, DAG, TaskDescription}
 import org.apache.gearpump.transport.Express
 import org.apache.gearpump.util.Graph
-import org.scalatest._
+import org.scalatest.{WordSpec, Matchers, BeforeAndAfterEach}
 import org.apache.gearpump.util.Graph._
+import org.mockito.Mockito.{mock, when, verify, times}
 
 class TaskActorSpec extends WordSpec with Matchers with BeforeAndAfterEach with MasterHarness {
   override def config = ConfigFactory.parseString(
@@ -40,8 +42,8 @@ class TaskActorSpec extends WordSpec with Matchers with BeforeAndAfterEach with 
     withFallback(TestUtil.DEFAULT_CONFIG)
 
   val appId = 0
-  val task1 = TaskDescription(classOf[TestActor].getName, 1)
-  val task2 = TaskDescription(classOf[TestActor].getName, 1)
+  val task1 = TaskDescription(classOf[TestTask].getName, 1)
+  val task2 = TaskDescription(classOf[TestTask].getName, 1)
   val dag = DAG(Graph(task1 ~ new HashPartitioner() ~> task2))
   val taskId1 = TaskId(0, 0)
   val taskId2 = TaskId(1, 0)
@@ -49,19 +51,21 @@ class TaskActorSpec extends WordSpec with Matchers with BeforeAndAfterEach with 
   val executorId2 = 2
 
   var mockMaster: TestProbe = null
-  var taskContext1: TaskContext = null
-  var taskContext2: TaskContext = null
+  var taskContext1: TaskContextData = null
+  var taskContext2: TaskContextData = null
 
   override def beforeEach() = {
     startActorSystem()
     mockMaster = TestProbe()(getActorSystem)
-    taskContext1 = TaskContext(taskId1, executorId1, appId, "appName", mockMaster.ref, 1, dag)
-    taskContext2 = TaskContext(taskId2, executorId2, appId, "appName", mockMaster.ref, 1, dag)
+    taskContext1 = TaskContextData(taskId1, executorId1, appId, "appName", mockMaster.ref, 1, dag)
+    taskContext2 = TaskContextData(taskId2, executorId2, appId, "appName", mockMaster.ref, 1, dag)
   }
 
   "TaskActor" should {
     "register itself to AppMaster when started" in {
-      val testActor = TestActorRef[TestActor](Props(classOf[TestActor], taskContext1, UserConfig.empty))(getActorSystem)
+
+      val mockTask = mock(classOf[TaskWrapper])
+      val testActor = TestActorRef[TaskActor](Props(classOf[TaskActor], taskContext1, UserConfig.empty, mockTask))(getActorSystem)
       val express1 = Express(getActorSystem)
       val testActorHost = express1.localHost
       mockMaster.expectMsg(RegisterTask(taskId1, executorId1, testActorHost))
@@ -76,23 +80,29 @@ class TaskActorSpec extends WordSpec with Matchers with BeforeAndAfterEach with 
 
     "throw RestartException when register to AppMaster time out" in {
       implicit val system = getActorSystem
+      val mockTask = mock(classOf[TaskWrapper])
       EventFilter[RestartException](occurrences = 1) intercept {
-        TestActorRef[TestActor](Props(classOf[TestActor], taskContext1, UserConfig.empty))(getActorSystem)
+        TestActorRef[TaskActor](Props(classOf[TaskActor], taskContext1, UserConfig.empty, mockTask))(getActorSystem)
       }
     }
 
     "transport message to target correctly" in {
-      val system1 = ActorSystem("TestActor", config)
-      val system2 = ActorSystem("Reporter", config)
-      val (testActor, echo) = StreamingTestUtil.createEchoForTaskActor(classOf[TestActor].getName, UserConfig.empty, system1, system2)
-      testActor.tell(Message("test"), testActor)
-      echo.expectMsg(Message("test"))
-      implicit val system = system1
+      val mockTask = mock(classOf[TaskWrapper])
+      val msg = Message("test")
+
+      val testActor = TestActorRef[TaskActor](Props(classOf[TaskActor], taskContext1, UserConfig.empty, mockTask))(getActorSystem)
+
+      testActor.tell(StartClock(0), mockMaster.ref)
+
+      testActor.tell(msg, testActor)
+
+      verify(mockTask, times(1)).onNext(msg);
+
+      implicit val system = getActorSystem
+
       EventFilter[RestartException](occurrences = 1) intercept {
         testActor ! RestartTask
       }
-      system1.shutdown()
-      system2.shutdown()
     }
   }
 
@@ -101,11 +111,6 @@ class TaskActorSpec extends WordSpec with Matchers with BeforeAndAfterEach with 
   }
 }
 
-class TestActor(taskContext : TaskContext, userConf : UserConfig) extends TaskActor(taskContext, userConf) {
-  override def onStart(startTime: StartTime): Unit = {
-  }
-
-  override def onNext(msg: Message): Unit = {
-    output(msg)
-  }
+object TaskActorSpec {
+  class TestTask
 }


### PR DESCRIPTION
The purpose of this PR is to sepeate the TaskActor and Task, so that we don't need to create a actor system just to test the function of a task.

I am NOT satified of this refactory considering the requirements in https://github.com/intel-hadoop/gearpump/issues/288 , but it should be much better than previsous code. 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/442)
<!-- Reviewable:end -->
