### PR TITLE
fix #394, close kafka producer on stop

### DIFF
--- a/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/KafkaStreamProducer.scala
+++ b/examples/kafka/src/main/scala/org/apache/gearpump/streaming/examples/kafka/KafkaStreamProducer.scala
@@ -53,4 +53,9 @@ class KafkaStreamProducer(taskContext : TaskContext, conf: UserConfig)
     source.pull(batchSize).foreach{msg => filter.filter(msg, startTime).map(output)}
     self ! Message("continue", System.currentTimeMillis())
   }
+
+  override def onStop(): Unit = {
+    LOG.info("closing kafka source...")
+    source.close()
+  }
 }

--- a/examples/sol/src/main/scala/org/apache/gearpump/streaming/examples/sol/SOLStreamProcessor.scala
+++ b/examples/sol/src/main/scala/org/apache/gearpump/streaming/examples/sol/SOLStreamProcessor.scala
@@ -38,7 +38,7 @@ class SOLStreamProcessor(taskContext : TaskContext, conf: UserConfig) extends Ta
   private var snapShotTime : Long = 0
 
   override def onStart(startTime : StartTime) : Unit = {
-    taskContext.schedule(new FiniteDuration(5, TimeUnit.SECONDS),
+    scheduler = taskContext.schedule(new FiniteDuration(5, TimeUnit.SECONDS),
       new FiniteDuration(5, TimeUnit.SECONDS))(reportWordCount())
     snapShotTime = System.currentTimeMillis()
   }
@@ -49,7 +49,9 @@ class SOLStreamProcessor(taskContext : TaskContext, conf: UserConfig) extends Ta
   }
 
   override def onStop() : Unit = {
-    scheduler.cancel()
+    if (scheduler != null) {
+      scheduler.cancel()
+    }
   }
 
   def reportWordCount() : Unit = {

--- a/examples/sol/src/test/scala/org/apache/gearpump/streaming/examples/sol/SOLStreamProcessorSpec.scala
+++ b/examples/sol/src/test/scala/org/apache/gearpump/streaming/examples/sol/SOLStreamProcessorSpec.scala
@@ -38,5 +38,6 @@ class SOLStreamProcessorSpec extends FlatSpec with Matchers {
     val msg = Message("msg")
     sol.onNext(msg)
     verify(context, times(1)).output(msg)
+    sol.onStop()
   }
 }

--- a/examples/wordcount/src/main/scala/org/apache/gearpump/streaming/examples/wordcount/Sum.scala
+++ b/examples/wordcount/src/main/scala/org/apache/gearpump/streaming/examples/wordcount/Sum.scala
@@ -38,7 +38,7 @@ class Sum (taskContext : TaskContext, conf: UserConfig) extends Task(taskContext
   private var scheduler : Cancellable = null
 
   override def onStart(startTime : StartTime) : Unit = {
-    taskContext.schedule(new FiniteDuration(5, TimeUnit.SECONDS),
+    scheduler = taskContext.schedule(new FiniteDuration(5, TimeUnit.SECONDS),
       new FiniteDuration(5, TimeUnit.SECONDS))(reportWordCount)
   }
 
@@ -52,7 +52,9 @@ class Sum (taskContext : TaskContext, conf: UserConfig) extends Task(taskContext
   }
 
   override def onStop() : Unit = {
-    scheduler.cancel()
+    if (scheduler != null) {
+      scheduler.cancel()
+    }
   }
 
   def reportWordCount() : Unit = {

--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/KafkaSource.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/KafkaSource.scala
@@ -85,4 +85,8 @@ class KafkaSource private[kafka](fetchThread: FetchThread,
     messagesBuilder.result().toList
   }
 
+  override def close(): Unit = {
+    offsetManagers.foreach(_._2.close())
+  }
+
 }

--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/KafkaOffsetManager.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/KafkaOffsetManager.scala
@@ -66,4 +66,8 @@ private[kafka] class KafkaOffsetManager(storage: OffsetStorage) extends OffsetMa
       case Failure(e) => throw e
     }
   }
+
+  override def close(): Unit = {
+    storage.close()
+  }
 }

--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/KafkaStorage.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/KafkaStorage.scala
@@ -80,6 +80,10 @@ private[kafka] class KafkaStorage(topic: String,
     producer.send(message)
   }
 
+  override def close(): Unit = {
+    producer.close()
+  }
+
   private[kafka] def load(consumer: KafkaConsumer): List[(TimeStamp, Array[Byte])] = {
     @annotation.tailrec
     def fetch(offsets: List[(TimeStamp, Array[Byte])]): List[(TimeStamp, Array[Byte])] = {

--- a/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/KafkaSourceSpec.scala
+++ b/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/KafkaSourceSpec.scala
@@ -123,4 +123,15 @@ class KafkaSourceSpec extends PropSpec with PropertyChecks with Matchers with Mo
     }
   }
 
+  property("KafkaSource close should close all offset managers") {
+    val offsetManager = mock[KafkaOffsetManager]
+    val messageDecoder = mock[MessageDecoder]
+    val topicAndPartition = mock[TopicAndPartition]
+    val fetchThread = mock[FetchThread]
+    val source = new KafkaSource(fetchThread, messageDecoder,
+      Map(topicAndPartition -> offsetManager))
+    source.close()
+    verify(offsetManager).close()
+  }
+
 }

--- a/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/lib/KafkaOffsetManagerSpec.scala
+++ b/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/lib/KafkaOffsetManagerSpec.scala
@@ -93,4 +93,11 @@ class KafkaOffsetManagerSpec extends PropSpec with PropertyChecks with Matchers 
         }
     }
   }
+
+  property("KafkaOffsetManager close should close offset storage") {
+    val offsetStorage = mock[OffsetStorage]
+    val offsetManager = new KafkaOffsetManager(offsetStorage)
+    offsetManager.close()
+    verify(offsetStorage).close()
+  }
 }

--- a/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/lib/KafkaStorageSpec.scala
+++ b/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/lib/KafkaStorageSpec.scala
@@ -168,4 +168,12 @@ class KafkaStorageSpec extends PropSpec with PropertyChecks with Matchers with M
       Try(kafkaStorage.load(consumer)).isFailure shouldBe true
     }
   }
+
+  property("KafkaStorage close should close kafka producer") {
+    val producer = mock[Producer[Array[Byte], Array[Byte]]]
+    val getConsumer = mock[() => KafkaConsumer]
+    val kafkaStorage = new KafkaStorage("topic", false, producer, getConsumer())
+    kafkaStorage.close()
+    verify(producer).close()
+  }
 }

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/api/OffsetManager.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/api/OffsetManager.scala
@@ -39,5 +39,7 @@ trait OffsetTimeStampResolver {
 /**
  * manages message's offset on TimeReplayableSource and timestamp
  */
-trait OffsetManager extends MessageFilter with OffsetTimeStampResolver
+trait OffsetManager extends MessageFilter with OffsetTimeStampResolver {
+  def close(): Unit
+}
 

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/api/OffsetStorage.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/api/OffsetStorage.scala
@@ -56,4 +56,5 @@ trait OffsetStorage {
    */
   def lookUp(time: TimeStamp): Try[Array[Byte]]
   def append(time: TimeStamp, offset: Array[Byte]): Unit
+  def close(): Unit
 }

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/api/TimeReplayableSource.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/transaction/api/TimeReplayableSource.scala
@@ -55,6 +55,8 @@ trait TimeReplayableSource {
    *  message count may be less than num
    */
   def pull(num: Int): List[Message]
+
+  def close(): Unit
 }
 
 


### PR DESCRIPTION
Changes include,

1. add `close` method to `OffsetStorage`, `OffsetManager` and `TimeReplayableSource`, and override in kafka implemenations. I cascade `close` to keep the fix simple and would decouple them in the future refactoring.
2. fix a bunch of `scheduler` issues

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/470)
<!-- Reviewable:end -->
