### PR TITLE
Fixes #464

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language:
 - java
 - scala
+- node_js
+node_js:
+- "0.12"
 before_install:
 - sudo pip install codecov
+before_script:
+  - npm install -g bower
+  - cd services 
+  - bower install 
+  - cd ..
 script: sbt clean coverage test
 jdk:
 - oraclejdk7


### PR DESCRIPTION
sbt-bower has only been released for 2.10. We would need to provide our own plugin with similar functionality.
For now travis will install bower before running the build.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/471)
<!-- Reviewable:end -->
