### PR TITLE
Fixes #467 Expose codahale metrics by rest service

### DIFF
--- a/conf/gear.conf
+++ b/conf/gear.conf
@@ -45,7 +45,7 @@ gearpump {
 
   ### Flag to enable metrics
   metrics {
-    enabled = false
+    enabled = true
 
     # We will take one metric out of ${sample.rate}
     sample-rate = 10
@@ -53,7 +53,8 @@ gearpump {
     report-interval-ms = 15000
 
     # reporter = "logfile"
-    reporter = "graphite"
+    # reporter = "graphite"
+    reporter = "akka"
 
     graphite {
       ## Graphite host settings

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -27,8 +27,9 @@ gearpump {
 
     report-interval-ms = 15000
 
-    # reporter = "logfile"
-    reporter = "graphite"
+    # reporter = "graphite"
+    # reporter = "akka"
+    reporter = "logfile"
 
     graphite {
       ## Graphite host settings

--- a/core/src/main/scala/org/apache/gearpump/cluster/ClusterMessage.scala
+++ b/core/src/main/scala/org/apache/gearpump/cluster/ClusterMessage.scala
@@ -24,6 +24,7 @@ import org.apache.gearpump.cluster.master.Master.{MasterInfo, MasterDescription}
 import org.apache.gearpump.cluster.scheduler.{Resource, ResourceAllocation, ResourceRequest}
 import org.apache.gearpump.cluster.worker.WorkerDescription
 
+import scala.reflect.ClassTag
 import scala.util.Try
 
 /**
@@ -106,11 +107,13 @@ object MasterToAppMaster {
   val AppMasterActive: AppMasterStatus = "active"
   val AppMasterInActive: AppMasterStatus = "inactive"
 
+  sealed trait StreamingType
   case class AppMasterData(appId: Int, appName: String, appMasterPath: String, workerPath: String, status: AppMasterStatus)
   case class AppMasterDataRequest(appId: Int, detail: Boolean = false)
   case class AppMastersData(appMasters: List[AppMasterData])
   case object AppMastersDataRequest
   case class AppMasterDataDetailRequest(appId: Int)
+  case class AppMasterMetricsRequest(appId: Int) extends StreamingType
 
   case class ReplayFromTimestampWindowTrailingEdge(appId: Int)
 
@@ -127,4 +130,5 @@ object WorkerToAppMaster {
   case class ShutdownExecutorSucceed(appId: Int, executorId: Int)
   case class ShutdownExecutorFailed(reason: String = null, ex: Throwable = null)
 }
+
 

--- a/core/src/main/scala/org/apache/gearpump/cluster/master/AppManager.scala
+++ b/core/src/main/scala/org/apache/gearpump/cluster/master/AppManager.scala
@@ -185,6 +185,15 @@ private[cluster] class AppManager(masterHA : ActorRef, kvService: ActorRef, laun
         case None =>
           sender ! AppMasterDataDetail(appId)
       }
+    case appMasterMetricsRequest: AppMasterMetricsRequest =>
+      val appId = appMasterMetricsRequest.appId
+      val (appMaster, info) = appMasterRegistry.getOrElse(appId, (null, null))
+      Option(appMaster) match {
+        case Some(_appMaster) =>
+          _appMaster forward appMasterMetricsRequest
+        case None =>
+      }
+
   }
 
   def workerMessage: Receive = {

--- a/core/src/main/scala/org/apache/gearpump/cluster/master/Master.scala
+++ b/core/src/main/scala/org/apache/gearpump/cluster/master/Master.scala
@@ -165,6 +165,9 @@ private[cluster] class Master extends Actor with Stash {
     case app : AppMasterDataDetailRequest =>
       LOG.info(s"Receive from client, forwarding to AppManager")
       appManager.forward(app)
+    case app : AppMasterMetricsRequest =>
+      LOG.info(s"AppMasterMetricsRequestFromActor Receive from client, forwarding to AppManager")
+      appManager.forward(app)
 
   }
 

--- a/core/src/main/scala/org/apache/gearpump/metrics/AkkaReporter.scala
+++ b/core/src/main/scala/org/apache/gearpump/metrics/AkkaReporter.scala
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.metrics
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.ActorSystem
+import com.codahale.metrics._
+import org.slf4j.Marker
+;
+
+/**
+ * A reporter class for logging metrics values to a remote actor periodically
+ */
+class AkkaReporter(system: ActorSystem, registry: MetricRegistry, marker: Marker, rateUnit:TimeUnit, durationUnit:TimeUnit, filter: MetricFilter) extends ScheduledReporter(registry, "akka-reporter", filter, rateUnit, durationUnit) {
+    override def report(gauges: java.util.SortedMap[String, com.codahale.metrics.Gauge[_]],
+                       counters: java.util.SortedMap[String, com.codahale.metrics.Counter],
+                       histograms: java.util.SortedMap[String, com.codahale.metrics.Histogram],
+                       meters: java.util.SortedMap[String, com.codahale.metrics.Meter],
+                       timers: java.util.SortedMap[String, com.codahale.metrics.Timer]): Unit = {
+      import scala.collection.JavaConversions._
+
+      val sgauges = collection.SortedMap(gauges.toSeq: _*)
+      sgauges.foreach(pair => {
+        import org.apache.gearpump.metrics.Metrics._
+        val (key, value) = pair
+        system.eventStream.publish(Gauge(key, value))
+      })
+
+      val scounters = collection.SortedMap(counters.toSeq: _*)
+      scounters.foreach(pair => {
+        import org.apache.gearpump.metrics.Metrics._
+        val (key, value: com.codahale.metrics.Counter) = pair
+        system.eventStream.publish(Counter(key, value.getCount))
+      })
+
+      val shistograms = collection.SortedMap(histograms.toSeq: _*)
+      shistograms.foreach(pair => {
+        import org.apache.gearpump.metrics.Metrics._
+        val (_, value: com.codahale.metrics.Histogram) = pair
+        val s = value.getSnapshot
+        system.eventStream.publish(Histogram(value.getCount, s.getMin, s.getMax, s.getMean, s.getStdDev,
+          s.getMedian, s.get75thPercentile, s.get95thPercentile, s.get98thPercentile, s.get99thPercentile, s.get999thPercentile))
+      })
+
+      val smeters = collection.SortedMap(meters.toSeq: _*)
+      smeters.foreach(pair => {
+        import org.apache.gearpump.metrics.Metrics._
+        val (key, value: com.codahale.metrics.Meter) = pair
+        system.eventStream.publish(Meter(key, value.getCount, convertRate(value.getMeanRate), convertRate(value.getOneMinuteRate), convertRate(value.getFiveMinuteRate),
+          convertRate(value.getFifteenMinuteRate), getRateUnit))
+      })
+
+      val stimers = collection.SortedMap(timers.toSeq: _*)
+      stimers.foreach(pair => {
+        import org.apache.gearpump.metrics.Metrics._
+        val (key, value: com.codahale.metrics.Timer) = pair
+        val s = value.getSnapshot
+        system.eventStream.publish(Timer(key, value.getCount, convertDuration(s.getMin), convertDuration(s.getMax), convertDuration(s.getMean),
+        convertDuration(s.getStdDev), convertDuration(s.getMedian), convertDuration(s.get75thPercentile), convertDuration(s.get95thPercentile), convertDuration(s.get98thPercentile),
+          convertDuration(s.get99thPercentile), convertDuration(s.get999thPercentile), convertRate(value.getMeanRate), convertRate(value.getOneMinuteRate),
+          convertRate(value.getFiveMinuteRate), convertRate(value.getFifteenMinuteRate), getRateUnit, getDurationUnit))
+
+      })
+    }
+
+    override def getRateUnit: String = {
+      "events/" + super.getRateUnit
+    }
+}
+
+object AkkaReporter {
+  case class Builder(registry: MetricRegistry, marker: Marker, var rateUnit: TimeUnit, var durationUnit: TimeUnit, var flter: MetricFilter) {
+
+    def build(system: ActorSystem) = {
+      new AkkaReporter(system, registry, marker, rateUnit, durationUnit, flter)
+    }
+
+    def convertRatesTo(ru: TimeUnit) = {
+      this.rateUnit = ru
+      this
+    }
+
+    def convertDurationsTo(du: TimeUnit) = {
+      this.durationUnit = du
+      this
+    }
+
+    def filter(f: MetricFilter) = {
+      this.flter = f
+      this
+    }
+  }
+
+  object Builder {
+    def apply(registry: MetricRegistry): Builder = Builder(registry, null, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, MetricFilter.ALL)
+  }
+  def forRegistry(registry: MetricRegistry): Builder = {
+    Builder(registry)
+  }
+}
+

--- a/core/src/main/scala/org/apache/gearpump/metrics/Metrics.scala
+++ b/core/src/main/scala/org/apache/gearpump/metrics/Metrics.scala
@@ -24,8 +24,11 @@ import java.util.concurrent.TimeUnit
 import akka.actor._
 import com.codahale.metrics.graphite.{Graphite, GraphiteReporter}
 import com.codahale.metrics.{Slf4jReporter, ConsoleReporter, MetricFilter, MetricRegistry}
+import org.apache.gearpump.TimeStamp
 import org.apache.gearpump.util.LogUtil
 import org.slf4j.Logger
+
+import scala.reflect.ClassTag
 
 class Metrics(sampleRate: Int) extends Extension {
 
@@ -47,6 +50,15 @@ class Metrics(sampleRate: Int) extends Extension {
 object Metrics extends ExtensionId[Metrics] with ExtensionIdProvider {
   val LOG: Logger = LogUtil.getLogger(getClass)
   import org.apache.gearpump.util.Constants._
+
+  sealed trait MetricType
+  case class Histogram(count: Long, min: Long, max: Long, mean: Double, stddev: Double, median: Double, p75: Double, p95: Double, p98: Double, p99: Double, p999: Double) extends MetricType
+  case class Counter(name: String, value: Long) extends MetricType
+  case class Meter(name: String, count: Long, meanRate: Double, m1: Double, m5: Double, m15: Double, rateUnit: String) extends MetricType
+  case class Timer(name: String, count: Long, min: Double, max: Double, mean: Double, stddev: Double,
+                   median: Double, p75: Double, p95: Double, p98: Double, p99: Double, p999: Double, meanRate: Double,
+                   m1: Double, m5: Double, m15: Double, rateUnit: String, durationUnit: String) extends MetricType
+  case class Gauge[T:ClassTag](name: String, value: T) extends MetricType
 
   override def get(system: ActorSystem): Metrics = super.get(system)
 
@@ -103,6 +115,21 @@ object Metrics extends ExtensionId[Metrics] with ExtensionIdProvider {
         })
       }
 
+      def startAkkaReporter = {
+
+        val reporter = AkkaReporter.forRegistry(meters.registry)
+          .convertRatesTo(TimeUnit.SECONDS)
+          .convertDurationsTo(TimeUnit.MILLISECONDS)
+          .filter(MetricFilter.ALL)
+          .build(system)
+
+        reporter.start(reportInterval, TimeUnit.MILLISECONDS)
+
+        system.registerOnTermination(new Runnable {
+          override def run = reporter.stop()
+        })
+      }
+
       val reporter = system.settings.config.getString(GEARPUMP_METRIC_REPORTER)
 
       LOG.info(s"Metrics reporter is enabled, using $reporter reporter")
@@ -110,6 +137,7 @@ object Metrics extends ExtensionId[Metrics] with ExtensionIdProvider {
       reporter match {
         case "graphite" => startGraphiteReporter
         case "logfile" => startSlf4jReporter
+        case "akka" => startAkkaReporter
         case other =>
           LOG.error(s"Metrics reporter will be disabled, as we cannot recognize reporter: $other")
       }

--- a/services/dashboard/index.html
+++ b/services/dashboard/index.html
@@ -145,6 +145,8 @@
 
     <!-- app -->
     <script src="scripts/app.js"></script>
+    <script src="scripts/services.js"></script>
+    <script src="scripts/controllers.js"></script>
     <script src="scripts/app-01.js"></script>
     <script src="scripts/app-02.js"></script>
     <script src="scripts/app-03.js"></script>

--- a/services/dashboard/scripts/controllers.js
+++ b/services/dashboard/scripts/controllers.js
@@ -23,29 +23,20 @@
  */
 'use strict';
 
-angular.module('app', [
-  // Angular modules
-  'ngRoute',
-  // Angular-dashboard-framework (including extensions)
-  'adf',
-  'structures',
-  // Application extensions
-  'app.tabset',
-  // Application controllers
-  'app-01',
-  'app-02',
-  'app-03'
-])
-.config(function($routeProvider){
-  $routeProvider.when('/cluster', {
-    templateUrl: 'partials/cluster.html',
-    controller: 'app01Ctrl'
-  }).when('/apps', {
-    templateUrl: 'partials/apps.html',
-    controller: 'app02Ctrl'
-  }).when('/app/:appId', {
-    templateUrl: 'partials/app.html',
-    controller: 'app03Ctrl'
-  }).otherwise({redirectTo: '/cluster'});
+angular.module('app')
+.controller('navigationCtrl', function($scope, $location){
+  $scope.navCollapsed = true;
 
+  $scope.toggleNav = function(){
+    $scope.navCollapsed = !$scope.navCollapsed;
+  };
+
+  $scope.$on('$routeChangeStart', function() {
+    $scope.navCollapsed = true;
+  });
+
+  $scope.navClass = function(page) {
+    var currentRoute = $location.path().substring(1) || 'Applications';
+    return page === currentRoute || new RegExp(page).test(currentRoute) ? 'active' : '';
+  };
 });

--- a/services/dashboard/scripts/services.js
+++ b/services/dashboard/scripts/services.js
@@ -1,0 +1,78 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2013, Sebastian Sdorra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+'use strict';
+
+angular.module('app')
+.constant('CONF', {WebSocketSendTimeout:500})
+.service('StreamingService', function(CONF) {
+  var StreamingService = (function(CONF) {
+    function StreamingService() {
+      this.wsUri = "ws://localhost:8091/";
+      this.onOpen = this.onOpen.bind(this);
+      this.onClose = this.onClose.bind(this);
+      this.onMessage = this.onMessage.bind(this);
+      this.onError = this.onError.bind(this);
+      this.send = this.send.bind(this);
+      this.websocket = new WebSocket(this.wsUri);
+      this.websocket.onopen = this.onOpen;
+      this.websocket.onclose = this.onClose;
+      this.websocket.onmessage = this.onMessage;
+      this.websocket.onerror = this.onError;
+    }
+    StreamingService.prototype.onOpen = function (evt) {
+      console.log("CONNECTED");
+    }
+    StreamingService.prototype.onClose = function (evt) {
+      console.log("DISCONNECTED");
+    }
+    StreamingService.prototype.onMessage = function (evt) {
+      console.log("MESSAGE "+evt.data);
+    }
+    StreamingService.prototype.onError = function (evt) {
+      console.log("ERROR "+evt.data);
+    }
+    StreamingService.prototype.send = function (data) {
+      function send() {
+        console.log("connected="+self.websocket.readyState);
+        switch(self.websocket.readyState) {
+          case 1:
+            console.log("SENDING "+data);
+            self.websocket.send(data);
+            break;
+          default:
+            setTimeout(send, CONF.WebSocketSendTimeout);
+            break;
+        }
+      }
+      try {
+        var self = this;
+        send();
+      } catch(e) {
+        console.log("Caught "+e.message);
+      }
+    }
+    return StreamingService;
+  })(CONF);
+  return new StreamingService;
+});

--- a/services/dashboard/scripts/widgets/visdag/visdag.js
+++ b/services/dashboard/scripts/widgets/visdag/visdag.js
@@ -37,7 +37,7 @@ angular.module('app.widgets.visdag', ['adf.provider'])
     }
   });
 })
-.controller('visDagCtrl', function ($scope, $http, $routeParams) {
+.controller('visDagCtrl', ['$scope','$http','$routeParams','StreamingService', function ($scope, $http, $routeParams, StreamingService) {
   var url = location.origin + '/appmaster/' + $routeParams.appId + '?detail=true';
   $http.get(url).then(function (response) {
     var json = response.data;
@@ -72,7 +72,8 @@ angular.module('app.widgets.visdag', ['adf.provider'])
       reset: true
     });
   });
-})
+  StreamingService.send(JSON.stringify(["org.apache.gearpump.cluster.MasterToAppMaster.AppMasterMetricsRequest",{appId:parseInt($routeParams.appId)}]));
+}])
 .directive('visdag', function () {
   function visdag(scope, el, attr) {
     var data = {

--- a/services/src/main/scala/org/apache/gearpump/cluster/main/Services.scala
+++ b/services/src/main/scala/org/apache/gearpump/cluster/main/Services.scala
@@ -47,8 +47,8 @@ object Services extends App with ArgumentsParser {
     implicit val system = ActorSystem("services" , ClusterConfig.load.application)
     val master = system.actorOf(MasterProxy.props(Util.parseHostList(masterList)), MASTER)
 
-    RestServices.start(master)
-    WebSocketServices.start(master)
+    WebSocketServices(master)
+    RestServices(master)
   }
   start()
 }

--- a/services/src/main/scala/org/apache/gearpump/services/RestServices.scala
+++ b/services/src/main/scala/org/apache/gearpump/services/RestServices.scala
@@ -29,7 +29,7 @@ trait RestServices extends AppMastersService
     with AppMasterService with WorkerService with WorkersService with MasterService with StaticService {
   implicit def executionContext = actorRefFactory.dispatcher
 
-  lazy val route = appMastersRoute ~ appMasterRoute ~ workersRoute ~ workerRoute ~ masterRoute ~ staticRoute
+  lazy val routes = appMastersRoute ~ appMasterRoute ~ workersRoute ~ workerRoute ~ masterRoute ~ staticRoute
 }
 
 class RestServicesActor(masters: ActorRef, sys:ActorSystem) extends Actor with RestServices {
@@ -38,13 +38,13 @@ class RestServicesActor(masters: ActorRef, sys:ActorSystem) extends Actor with R
   implicit val eh = RoutingSettings.default(context)
 
   val master = masters
-  def receive = runRoute(route)
+  def receive = runRoute(routes)
 }
 
 object RestServices {
   private val LOG = LogUtil.getLogger(getClass)
 
-  def start(master:ActorRef)(implicit system:ActorSystem) {
+  def apply(master:ActorRef)(implicit system:ActorSystem) {
     implicit val executionContext = system.dispatcher
     val services = system.actorOf(Props(classOf[RestServicesActor], master, system), "rest-services")
     val config = system.settings.config
@@ -52,7 +52,7 @@ object RestServices {
     val host = config.getString("gearpump.services.host")
     IO(Http) ! Http.Bind(services, interface = host, port = port)
 
-    LOG.info(s"Please browser http://$host:$port to see the web UI")
-    println(s"Please browser http://$host:$port to see the web UI")
+    LOG.info(s"Please browse to http://$host:$port to see the web UI")
+    println(s"Please browse to http://$host:$port to see the web UI")
   }
 }

--- a/services/src/main/scala/org/apache/gearpump/services/WebSocketServices.scala
+++ b/services/src/main/scala/org/apache/gearpump/services/WebSocketServices.scala
@@ -22,32 +22,40 @@ import akka.actor._
 import akka.io.IO
 import org.apache.gearpump.cluster.ClusterConfig
 import org.apache.gearpump.cluster.main.Local._
-import org.apache.gearpump.util.LogUtil
+import org.apache.gearpump.util.{Constants, LogUtil}
 import org.apache.gearpump.util.LogUtil.ProcessType
 import org.slf4j.Logger
 import spray.can.Http
 import spray.can.server.UHttp
 
-class WebSocketServices(masters: ActorRef) extends Actor with ActorLogging {
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class WebSocketServices(master: ActorRef) extends Actor with ActorLogging {
   def receive = {
-    // when a new connection comes in we register a WebSocketConnection actor as the per connection handler
     case Http.Connected(remoteAddress, localAddress) =>
-      val serverConnection = sender()
-      val conn = context.actorOf(WebSocketWorker.props(serverConnection))
-      serverConnection ! Http.Register(conn)
+      sender ! Http.Register(WebSocketWorker(sender, master))
   }
 }
 
 object WebSocketServices {
+  private val LOG = LogUtil.getLogger(getClass)
 
-  def start(master:ActorRef) {
-    implicit val system = ActorSystem("ws-services" , ClusterConfig.load.application)
+  def apply(master:ActorRef)(implicit system:ActorSystem) {
     implicit val executionContext = system.dispatcher
+    implicit val timeout = Constants.FUTURE_TIMEOUT
     val services = system.actorOf(Props(classOf[WebSocketServices], master),"ws-services")
     val config = system.settings.config
     val port = config.getInt("gearpump.services.ws")
     val host = config.getString("gearpump.services.host")
     IO(UHttp) ! Http.Bind(services, interface = host, port = port)
+    Option(Await.result(system.actorSelection("user/IO-HTTP").resolveOne(), Duration.Inf)).map(iohttp => {
+      system.stop(iohttp)
+    })
+
+    LOG.info(s"WebSocket server is enabled http://$host:$port")
+    println(s"WebSocket server is enabled http://$host:$port")
+
   }
 }
 

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskActor.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskActor.scala
@@ -23,11 +23,11 @@ import java.util
 import akka.actor._
 import org.apache.gearpump.cluster.UserConfig
 import org.apache.gearpump.metrics.Metrics
+import org.apache.gearpump.metrics.Metrics.MetricType
 import org.apache.gearpump.partitioner.Partitioner
 import org.apache.gearpump.streaming.AppMasterToExecutor._
-import org.apache.gearpump.streaming.executor.Executor
-import Executor.TaskLocationReady
 import org.apache.gearpump.streaming.ExecutorToAppMaster._
+import org.apache.gearpump.streaming.executor.Executor.TaskLocationReady
 import org.apache.gearpump.util.{LogUtil, TimeOutScheduler, Util}
 import org.apache.gearpump.{Message, TimeStamp}
 import org.slf4j.Logger
@@ -38,7 +38,6 @@ class TaskActor(val taskContextData : TaskContextData, userConf : UserConfig, va
   import taskContextData._
 
   val LOG: Logger = LogUtil.getLogger(getClass, app = appId, executor = executorId, task = taskId)
-
   private val metricName = s"app${appId}.task${taskId.groupId}_${taskId.index}"
   private val latencies = Metrics(context.system).histogram(s"$metricName.latency")
   private val throughput = Metrics(context.system).meter(s"$metricName.throughput")
@@ -104,6 +103,7 @@ class TaskActor(val taskContextData : TaskContextData, userConf : UserConfig, va
   final override def preStart() : Unit = {
 
     sendMsgWithTimeOutCallBack(appMaster, RegisterTask(taskId, executorId, local), 10, registerTaskTimeOut())
+    system.eventStream.subscribe(taskContextData.appMaster, classOf[MetricType])
 
     val graph = dag.graph
     LOG.info(s"TaskInit... taskId: $taskId")
@@ -176,7 +176,7 @@ class TaskActor(val taskContextData : TaskContextData, userConf : UserConfig, va
         msg match {
           case SendAck(ack, targetTask) =>
             transport(ack, targetTask)
-            LOG.debug("Sending ack back, taget taskId: " + taskId + ", my task: " + taskId + ", received message: " + ack.actualReceivedNum)
+            LOG.info(s"Sending ack back, target taskId: $taskId, my task: $taskId, received message: ${ack.actualReceivedNum}")
           case m : Message =>
             val updated = clockTracker.onProcess(m)
             if (updated) {
@@ -230,7 +230,6 @@ class TaskActor(val taskContextData : TaskContextData, userConf : UserConfig, va
         doHandleMessage()
       }
     case inputMessage: Message =>
-
       val messageAfterCheck = securityChecker.checkMessage(inputMessage, sender)
       messageAfterCheck match {
         case Some(msg) =>


### PR DESCRIPTION
Metrics (throughput, meter) are now streamed into the browser using websockets. A few issues remain:

- the socket address is hardcoded. We need to add a REST call asking for the streaming address
- the metrics should be enabled dynamically, also via a REST call.
- the output is only being streamed to the browser console, so we need meter and histogram widgets

I'll open separate issues on the above.

Sample output is below
````
 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task1_0.throughput","count":"0","mean_rate":0,"m1":0,"m5":0,"m15":0,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task1_1.throughput","count":"0","mean_rate":0,"m1":0,"m5":0,"m15":0,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Histogram",{"count":"4824","min":"0","max":"2","mean":0.017509727626459144,"stddev":0.15186226303946004,"median":0,"p75":0,"p95":0,"p98":0,"p99":1,"p999":2}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Histogram",{"count":"4845","min":"0","max":"3","mean":0.02529182879377432,"stddev":0.1906847509548179,"median":0,"p75":0,"p95":0,"p98":1,"p99":1,"p999":3}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Histogram",{"count":"322574","min":"0","max":"257","mean":10.728599221789883,"stddev":15.30848894155429,"median":5,"p75":19,"p95":31.549999999999955,"p98":45.25999999999988,"p99":58.710000000000036,"p999":253.1140000000005}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Histogram",{"count":"745941","min":"0","max":"204","mean":19.92509727626459,"stddev":24.10887412505352,"median":16,"p75":28,"p95":63,"p98":91.83999999999992,"p99":108.71000000000004,"p999":203.1010000000001}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task0_2.throughput","count":"5403540","mean_rate":183232.45704208137,"m1":92708.48408242757,"m5":58156.65737226059,"m15":51516.751634258755,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task0_3.throughput","count":"5427170","mean_rate":184032.84478161833,"m1":91360.3410237763,"m5":55427.11283530134,"m15":48519.20508003388,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task1_2.throughput","count":"0","mean_rate":0,"m1":0,"m5":0,"m15":0,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task1_3.throughput","count":"0","mean_rate":0,"m1":0,"m5":0,"m15":0,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Histogram",{"count":"8571","min":"0","max":"4","mean":0.021400778210116732,"stddev":0.21055216247999536,"median":0,"p75":0,"p95":0,"p98":0,"p99":1,"p999":3.9710000000000036}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Histogram",{"count":"8616","min":"0","max":"1","mean":0.011673151750972763,"stddev":0.10746219270851418,"median":0,"p75":0,"p95":0,"p98":0,"p99":1,"p999":1}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Histogram",{"count":"760347","min":"0","max":"166","mean":10.802529182879377,"stddev":14.733296399933725,"median":5,"p75":19,"p95":31,"p98":50.41999999999996,"p99":66,"p999":164.14400000000023}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Histogram",{"count":"1190110","min":"0","max":"523","mean":18.89591439688716,"stddev":44.85156589065409,"median":10,"p75":23,"p95":47.549999999999955,"p98":171.41999999999996,"p99":208.1300000000001,"p999":523}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task0_0.throughput","count":"9600130","mean_rate":215851.3315306094,"m1":130252.01744908477,"m5":65579.25228108342,"m15":51747.423379528045,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task0_1.throughput","count":"9650650","mean_rate":216985.53109769948,"m1":130455.7266643321,"m5":65457.60155521281,"m15":51545.34079973788,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task1_0.throughput","count":"0","mean_rate":0,"m1":0,"m5":0,"m15":0,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task1_1.throughput","count":"0","mean_rate":0,"m1":0,"m5":0,"m15":0,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Histogram",{"count":"7918","min":"0","max":"2","mean":0.014591439688715954,"stddev":0.135230800596823,"median":0,"p75":0,"p95":0,"p98":0,"p99":1,"p999":2}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Histogram",{"count":"7962","min":"0","max":"1","mean":0.01556420233463035,"stddev":0.1238421458205842,"median":0,"p75":0,"p95":0,"p98":0,"p99":1,"p999":1}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Histogram",{"count":"529107","min":"0","max":"257","mean":10.130350194552529,"stddev":14.20775509512902,"median":3.5,"p75":19,"p95":30,"p98":34.83999999999992,"p99":49.710000000000036,"p999":251.92500000000064}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Histogram",{"count":"1223498","min":"0","max":"173","mean":16.782101167315176,"stddev":19.95796923999278,"median":14,"p75":26,"p95":53,"p98":73.41999999999996,"p99":94.71000000000004,"p999":172.39100000000008}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task0_2.throughput","count":"8869620","mean_rate":199413.65377460243,"m1":124289.781369239,"m5":66808.89289561761,"m15":54559.00978649944,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task0_3.throughput","count":"8917970","mean_rate":200500.24958070845,"m1":123518.07218440622,"m5":64268.78299059287,"m15":51629.79999029154,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task1_2.throughput","count":"0","mean_rate":0,"m1":0,"m5":0,"m15":0,"rate_unit":"events/second"}]
app.js:92 MESSAGE ["org.apache.gearpump.metrics.Metrics.Meter",{"name":"app1.task1_3.throughput","count":"0","mean_rate":0,"m1":0,"m5":0,"m15":0,"rate_unit":"events/second"}]
app.js:89
````

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/520)
<!-- Reviewable:end -->
