### PR TITLE
fix #568, [REST] add history metrics service in backend so that the UI d...

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -40,6 +40,30 @@ gearpump {
     logfile {
 
     }
+
+    ## Coarse-grain history metrics, which have a larger timespan but sparse data points
+    retainHistoryData {
+      # max hours of history data to retain
+      # Note: due to implementation limitation(we store all history in memory),
+      # please don't set this to too big which may exhaust memory.
+      hours = 72
+
+      # time interval between two data points for history data (unit: ms)
+      # Usually this value is set to a big value so that we only store
+      # coarse-grain data
+      intervalMs = 3600000
+    }
+
+    ## fine-grain recent metrics which just happened, which have a smaller timespan but dense data points
+    retainRecentData {
+
+      # max seconds of recent data to retain,
+      # THis is for the fine-grain data
+      seconds = 300
+
+      # time interval between two data points for recent data (unit: ms)
+      intervalMs = 15000
+    }
   }
 
   #######################################

--- a/core/src/main/scala/org/apache/gearpump/cluster/ClusterMessage.scala
+++ b/core/src/main/scala/org/apache/gearpump/cluster/ClusterMessage.scala
@@ -24,6 +24,8 @@ import org.apache.gearpump.TimeStamp
 import org.apache.gearpump.cluster.master.Master.{MasterInfo, MasterDescription}
 import org.apache.gearpump.cluster.scheduler.{Resource, ResourceAllocation, ResourceRequest}
 import org.apache.gearpump.cluster.worker.WorkerDescription
+import org.apache.gearpump.metrics.Metrics._
+import upickle._
 
 import scala.reflect.ClassTag
 import scala.util.Try
@@ -55,6 +57,8 @@ object ClientToMaster {
   case object GetJarFileContainer
 
   case class QueryAppMasterConfig(appId: Int)
+
+  case class QueryHistoryMetrics(appId: Int, path: String)
 }
 
 object MasterToClient {
@@ -64,6 +68,10 @@ object MasterToClient {
   case class ResolveAppIdResult(appMaster: Try[ActorRef])
 
   case class AppMasterConfig(config: Config)
+
+  case class HistoryMetricsItem(time: TimeStamp, value: MetricType)
+
+  case class HistoryMetrics(appId: Int, path: String, metrics: List[HistoryMetricsItem])
 }
 
 trait AppMasterRegisterData

--- a/core/src/main/scala/org/apache/gearpump/cluster/master/AppManager.scala
+++ b/core/src/main/scala/org/apache/gearpump/cluster/master/AppManager.scala
@@ -229,6 +229,13 @@ private[cluster] class AppManager(masterHA : ActorRef, kvService: ActorRef, laun
         case None =>
       }
 
+    case query@ QueryHistoryMetrics(appId, _) =>
+      val (appMaster, info) = appMasterRegistry.getOrElse(appId, (null, null))
+      Option(appMaster) match {
+        case Some(_appMaster) =>
+          _appMaster forward query
+        case None =>
+      }
   }
 
   def workerMessage: Receive = {

--- a/core/src/main/scala/org/apache/gearpump/cluster/master/Master.scala
+++ b/core/src/main/scala/org/apache/gearpump/cluster/master/Master.scala
@@ -104,15 +104,6 @@ private[cluster] class Master extends Actor with Stash {
     case registerAppMaster : RegisterAppMaster =>
       //forward to appManager
       appManager forward registerAppMaster
-    case AppMastersDataRequest =>
-      LOG.info("Master received AppMastersDataRequest")
-      appManager forward AppMastersDataRequest
-    case appMasterDataRequest: AppMasterDataRequest =>
-      LOG.info("Master received AppMasterDataRequest")
-      appManager forward appMasterDataRequest
-    case query: QueryAppMasterConfig =>
-      LOG.info("Master received QueryAppMasterConfig")
-      appManager forward query
     case save : SaveAppData =>
       appManager forward save
     case get : GetAppData =>
@@ -172,6 +163,18 @@ private[cluster] class Master extends Actor with Stash {
       LOG.info(s"AppMasterMetricsRequestFromActor Receive from client, forwarding to AppManager")
       appManager.forward(app)
 
+    case AppMastersDataRequest =>
+      LOG.info("Master received AppMastersDataRequest")
+      appManager forward AppMastersDataRequest
+    case appMasterDataRequest: AppMasterDataRequest =>
+      LOG.info("Master received AppMasterDataRequest")
+      appManager forward appMasterDataRequest
+    case query: QueryAppMasterConfig =>
+      LOG.info("Master received QueryAppMasterConfig")
+      appManager forward query
+    case query: QueryHistoryMetrics =>
+      LOG.info("Master received QueryHistoryMetrics")
+      appManager forward query
   }
 
   def disassociated : Receive = {

--- a/core/src/main/scala/org/apache/gearpump/util/Constants.scala
+++ b/core/src/main/scala/org/apache/gearpump/util/Constants.scala
@@ -79,4 +79,16 @@ object Constants {
   val GEARPUMP_METRIC_GRAPHITE_PORT = "gearpump.metrics.graphite.port"
   val GEARPUMP_METRIC_REPORTER = "gearpump.metrics.reporter"
 
+  // we will retain at max @RETAIN_HISTORY_HOURS history data
+  val GEARPUMP_METRIC_RETAIN_HISTORY_DATA_HOURS = "gearpump.metrics.retainHistoryData.hours"
+
+  // time interval between two history data points.
+  val GEARPUMP_RETAIN_HISTORY_DATA_INTERVAL_MS = "gearpump.metrics.retainHistoryData.intervalMs"
+
+  // we will retain at max @RETAIN_LATEST_SECONDS recent data points
+  val GEARPUMP_RETAIN_RECENT_DATA_SECONDS = "gearpump.metrics.retainRecentData.seconds"
+
+  // time interval between two recent data points.
+  val GEARPUMP_RETAIN_RECENT_DATA_INTERVAL_MS = "gearpump.metrics.retainRecentData.intervalMs"
+
 }

--- a/services/src/main/scala/org/apache/gearpump/services/MetricsQueryService.scala
+++ b/services/src/main/scala/org/apache/gearpump/services/MetricsQueryService.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.services
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.pattern.ask
+import org.apache.gearpump._
+import org.apache.gearpump.cluster.ClientToMaster.{QueryHistoryMetrics, QueryAppMasterConfig}
+import org.apache.gearpump.cluster.MasterToClient.{HistoryMetrics, AppMasterConfig}
+import org.apache.gearpump.metrics.Metrics.{MetricType, Meter, Histogram}
+
+import org.apache.gearpump.util.{Constants, LogUtil}
+import spray.http.StatusCodes
+import spray.routing.HttpService
+import upickle.Js
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+trait MetricsQueryService extends HttpService  {
+  def master:ActorRef
+  implicit val system: ActorSystem
+  private val LOG = LogUtil.getLogger(getClass)
+
+  def appMasterRoute = get {
+    implicit val ec: ExecutionContext = actorRefFactory.dispatcher
+    implicit val timeout = Constants.FUTURE_TIMEOUT
+    path("metrics"/"app"/IntNumber/Rest) { (appId, path) =>
+      onComplete((master ? QueryHistoryMetrics(appId, path)).asInstanceOf[Future[HistoryMetrics]]) {
+        case Success(value: HistoryMetrics) =>
+          complete(upickle.write(value))
+        case Failure(ex) =>
+          complete(StatusCodes.InternalServerError, s"An error occurred: ${ex.getMessage}")
+      }
+    }
+  }
+}

--- a/services/src/main/scala/org/apache/gearpump/services/WebSocketWorker.scala
+++ b/services/src/main/scala/org/apache/gearpump/services/WebSocketWorker.scala
@@ -52,20 +52,7 @@ class WebSocketWorker(val serverConnection: ActorRef, val master: ActorRef) exte
 
     case metrics: MetricType =>
       LOG.info("writing metrics")
-      metrics match {
-        case histogram: Histogram =>
-          client ! TextFrame(write(histogram))
-        case counter: Counter =>
-          client ! TextFrame(write(counter))
-        case meter: Meter =>
-          client ! TextFrame(write(meter))
-        case timer: Timer =>
-          client ! TextFrame(write(timer))
-        case gauge: Gauge[_] =>
-          LOG.error("cannot handle gauge")
-        case _ =>
-          LOG.error("unknown type")
-      }
+      client ! TextFrame(write(metrics))
 
     case Push(msg) => send(TextFrame(msg))
 

--- a/services/src/test/scala/org/apache/gearpump/services/MetricsQueryServiceSpec.scala
+++ b/services/src/test/scala/org/apache/gearpump/services/MetricsQueryServiceSpec.scala
@@ -18,7 +18,7 @@
 
 package org.apache.gearpump.services
 
-import org.apache.gearpump.cluster.MasterToAppMaster.AppMasterData
+import com.typesafe.config.ConfigFactory
 import org.apache.gearpump.cluster.TestUtil
 import org.apache.gearpump.cluster.TestUtil.MiniCluster
 import org.apache.gearpump.streaming.StreamingTestUtil
@@ -26,12 +26,11 @@ import org.apache.gearpump.util.LogUtil
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import org.slf4j.Logger
 import spray.testkit.ScalatestRouteTest
-import com.typesafe.config.{ConfigFactory}
+
 import scala.concurrent.duration._
 import scala.util.Try
 
-class ConfigQueryServiceSpec extends FlatSpec with ScalatestRouteTest with ConfigQueryService with Matchers with BeforeAndAfterAll {
-  import upickle._
+class MetricsQueryServiceSpec extends FlatSpec with ScalatestRouteTest with MetricsQueryService with Matchers with BeforeAndAfterAll {
   private val LOG: Logger = LogUtil.getLogger(getClass)
   def actorRefFactory = system
 
@@ -41,17 +40,15 @@ class ConfigQueryServiceSpec extends FlatSpec with ScalatestRouteTest with Confi
   override def beforeAll: Unit = {
     miniCluster = TestUtil.startMiniCluster
     StreamingTestUtil.startAppMaster(miniCluster, 0)
-
-    Thread.sleep(1000)
   }
 
   override def afterAll: Unit = {
     miniCluster.shutDown()
   }
 
-  "ConfigQueryService" should "return config for application" in {
+  "MetricsQueryService" should "return history metrics" in {
     implicit val customTimeout = RouteTestTimeout(15.seconds)
-    (Get("/config/app/0") ~> appMasterRoute).asInstanceOf[RouteResult] ~> check{
+    (Get("/metrics/app/0/processor") ~> appMasterRoute).asInstanceOf[RouteResult] ~> check{
       val responseBody = response.entity.asString
       val config = Try(ConfigFactory.parseString(responseBody))
       assert(config.isSuccess)

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/HistoryMetricsService.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/HistoryMetricsService.scala
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.appmaster
+
+import java.util
+
+import akka.actor.Actor
+import org.apache.gearpump.cluster.ClientToMaster.QueryHistoryMetrics
+import org.apache.gearpump.cluster.MasterToClient.{HistoryMetrics, HistoryMetricsItem}
+import org.apache.gearpump.metrics.Metrics.{Histogram, MetricType, Meter, Counter}
+import org.apache.gearpump.streaming.appmaster.HistoryMetricsService.{HistoryMetricsConfig, MetricsStore}
+import org.apache.gearpump.util.LogUtil
+import org.slf4j.Logger
+
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Metrics service to serve history metrics data
+ * @param appId
+ */
+class HistoryMetricsService(appId: Int, config: HistoryMetricsConfig) extends Actor {
+  private val LOG: Logger = LogUtil.getLogger(getClass, app = appId)
+  private var metricsStore = Map.empty[String, MetricsStore]
+
+  def receive: Receive = metricHandler orElse commandHandler
+
+  def metricHandler: Receive = {
+    case metrics: MetricType =>
+      val name = metrics.name
+      if (metricsStore.contains(name)) {
+        metricsStore(name).add(metrics)
+      } else {
+        val store = MetricsStore(name, metrics, config)
+        metricsStore += name -> store
+        store.add(metrics)
+      }
+  }
+
+  def commandHandler: Receive = {
+    case QueryHistoryMetrics(appId, path) =>
+      LOG.info(s"Query History Metrics $path")
+
+      // For now, we only do prefix match, in the future we may support
+      // wildcard match, using character "*"
+      // Caution: Avoid using regular expression, as it may introduce
+      // security problem, like catastrophic backtracking
+
+      val result = new ListBuffer[HistoryMetricsItem]
+      metricsStore.keys.foreach {name =>
+        if (name.startsWith(path)) {
+          result.append(metricsStore(name).read :_*)
+        }
+      }
+      sender ! HistoryMetrics(appId, path, result.toList)
+  }
+}
+
+object HistoryMetricsService {
+
+  /**
+   * For simplicity, HistoryMetricsService will maintain 72 hours coarse-grained data
+   * for last 72 hours, and fine-grained data for past 5 min.
+   *
+   * For the coarse-grained data of past 72 hours, one or two sample point will be stored
+   * for each hour.
+   *
+   * For Counter: we will store one data point per hour.
+   * For Meter, we will store two data points per hour, with one point which have
+   * max mean value, the other point with min mean value.
+   * For Histogram: we will store two data points per hour, with one point which have
+   * max mean value, the other point with min mean value.
+   *
+   * It is designed like this so that we are able to maintain abnormal metrics pattern,
+   * Like a sudden rise in latency, so a sudden drop in throughput.
+   *
+   * For fine-grained data in last 5 min, there will be 1 sample point per 15 seconds.
+   *
+   */
+  trait MetricsStore {
+    def add(inputMetrics: MetricType): Unit
+
+    def read: List[HistoryMetricsItem]
+  }
+
+  object MetricsStore {
+    def apply(name: String, metric: MetricType, config: HistoryMetricsConfig): MetricsStore = {
+      metric match {
+        case histogram: Histogram => new HistogramMetricsStore(config)
+        case meter: Meter => new MeterMetricsStore(config)
+        case counter: Counter => new CounterMetricsStore(config)
+        case _ => null //NOT supported
+      }
+    }
+  }
+
+  /**
+   * min, and max data point for current time window (startTimeMs, startTimeMs + interval)
+   *
+   * @param startTimeMs
+   * @param min
+   * @param max
+   */
+  case class MinMaxMetrics(startTimeMs: Long, min: HistoryMetricsItem, max: HistoryMetricsItem)
+
+  /**
+   * Metrics store to store history data points
+   * For each time point, we will store two data points, with one min, and one max.
+   *
+   * @param retainCount how many data points to retain, old data will be removed
+   * @param retainIntervalMs time interval between two data points.
+   * @param compare (left, right) => true, return true when left > right
+   *   We should compare to decide which data point to keep in current time interval.
+   *   The data point which is max or min in value will be kept.
+   *
+   */
+  class MinMaxMetricsStore(
+      retainCount: Int,
+      retainIntervalMs: Long,
+      compare: (HistoryMetricsItem, HistoryMetricsItem) => Boolean)
+    extends MetricsStore{
+
+    val queue = new util.ArrayDeque[MinMaxMetrics]()
+
+    def add(inputMetrics: MetricType): Unit = {
+      val now = System.currentTimeMillis()
+      val metrics = HistoryMetricsItem(now, inputMetrics)
+      val head = queue.peek()
+      if (head == null || now - head.startTimeMs > retainIntervalMs) {
+        //insert new data point to head
+        queue.addFirst(MinMaxMetrics(now / retainIntervalMs * retainIntervalMs, metrics, metrics))
+        // remove old data if necessary
+        if (queue.size() > retainCount) {
+          queue.removeLast()
+        }
+      } else {
+        updateHead(metrics)
+      }
+    }
+
+    private def updateHead(metrics: HistoryMetricsItem) = {
+      val head = queue.poll()
+      if (compare(metrics, head.max)) {
+        queue.addFirst(MinMaxMetrics(head.startTimeMs, head.min, metrics))
+      } else if (compare(metrics, head.min)) {
+        queue.addFirst(MinMaxMetrics(head.startTimeMs, metrics, head.max))
+      }
+    }
+
+    def read: List[HistoryMetricsItem] = {
+      val result = new ListBuffer[HistoryMetricsItem]
+      import scala.collection.JavaConversions.asScalaIterator
+      queue.iterator.foreach {pair =>
+          result.prepend(pair.max)
+        result.prepend(pair.min)
+      }
+      result.toList
+    }
+  }
+
+  /**
+   ** Metrics store to store history data points
+   * For each time point, we will store single data point.
+   *
+   * @param retainCount how many data points to retain, old data will be removed
+   * @param retainIntervalMs time interval between two data points.
+   */
+  class SingleValueMetricsStore (retainCount: Int, retainIntervalMs: Long) extends MetricsStore{
+
+    val queue =  new util.ArrayDeque[HistoryMetricsItem]()
+
+    def add(inputMetrics: MetricType): Unit = {
+      val now = System.currentTimeMillis()
+      val head = queue.peek()
+      if (head == null || now - head.time > retainIntervalMs) {
+
+        queue.addFirst(HistoryMetricsItem(now, inputMetrics))
+
+        // remove old data
+        if (queue.size() > retainCount) {
+          queue.removeLast()
+        }
+      }
+    }
+
+    def read: List[HistoryMetricsItem] = {
+      val result = new ListBuffer[HistoryMetricsItem]
+      import scala.collection.JavaConversions.asScalaIterator
+      queue.iterator().foreach(result.prepend(_))
+      result.toList
+    }
+  }
+
+  /**
+   *
+   * @param retainHistoryDataHours Retain at max @RETAIN_HISTORY_HOURS history data(unit hour)
+   * @param retainHistoryDataIntervalMs time interval between two history data points.(unit: ms)
+   * @param retainRecentDataSeconds Retain at max @RETAIN_LATEST_SECONDS recent data points(unit: seconds)
+   * @param retainRecentDataIntervalMs Retain at max @RETAIN_LATEST_SECONDS recent data points(unit: ms)
+   */
+  case class HistoryMetricsConfig(
+      retainHistoryDataHours: Int,
+      retainHistoryDataIntervalMs: Int,
+      retainRecentDataSeconds: Int,
+      retainRecentDataIntervalMs: Int)
+
+  class HistogramMetricsStore(config: HistoryMetricsConfig) extends MetricsStore {
+
+    private val compartor = (left: HistoryMetricsItem, right: HistoryMetricsItem) =>
+      left.value.asInstanceOf[Histogram].mean > right.value.asInstanceOf[Histogram].mean
+
+    private val history = new MinMaxMetricsStore(
+      config.retainHistoryDataHours * 3600 * 1000 / config.retainHistoryDataIntervalMs,
+      config.retainHistoryDataIntervalMs, compartor)
+
+    private val recent = new SingleValueMetricsStore(
+      config.retainRecentDataSeconds * 1000 / config.retainRecentDataIntervalMs,
+      config.retainRecentDataIntervalMs)
+
+    override def add(inputMetrics: MetricType): Unit = {
+      recent.add(inputMetrics)
+      history.add(inputMetrics)
+    }
+
+    override def read: List[HistoryMetricsItem] = {
+      history.read ++ recent.read
+    }
+  }
+
+  class MeterMetricsStore(config: HistoryMetricsConfig) extends MetricsStore {
+
+    private val compartor = (left: HistoryMetricsItem, right: HistoryMetricsItem) =>
+      left.value.asInstanceOf[Meter].meanRate > right.value.asInstanceOf[Meter].meanRate
+
+    private val history = new MinMaxMetricsStore(
+      config.retainHistoryDataHours * 3600 * 1000 / config.retainHistoryDataIntervalMs,
+      config.retainHistoryDataIntervalMs, compartor)
+
+    private val recent = new SingleValueMetricsStore(
+      config.retainRecentDataSeconds * 1000 / config.retainRecentDataIntervalMs,
+      config.retainRecentDataIntervalMs)
+
+    override def add(inputMetrics: MetricType): Unit = {
+      recent.add(inputMetrics)
+      history.add(inputMetrics)
+    }
+
+    override def read: List[HistoryMetricsItem] = {
+      history.read ++ recent.read
+    }
+  }
+
+  class CounterMetricsStore(config: HistoryMetricsConfig) extends MetricsStore {
+
+    private val history = new SingleValueMetricsStore(
+      config.retainHistoryDataHours * 3600 * 1000 / config.retainHistoryDataIntervalMs,
+      config.retainHistoryDataIntervalMs)
+
+    private val recent = new SingleValueMetricsStore(
+      config.retainRecentDataSeconds * 1000 / config.retainRecentDataIntervalMs,
+      config.retainRecentDataIntervalMs)
+
+    override def add(inputMetrics: MetricType): Unit = {
+      history.add(inputMetrics)
+      recent.add(inputMetrics)
+    }
+
+    override def read: List[HistoryMetricsItem] = {
+      history.read ++ recent.read
+    }
+  }
+}

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskActor.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskActor.scala
@@ -41,7 +41,7 @@ class TaskActor(val taskContextData : TaskContextData, userConf : UserConfig, va
   val LOG: Logger = LogUtil.getLogger(getClass, app = appId, executor = executorId, task = taskId)
 
   //metrics
-  private val metricName = s"app${appId}.task${taskId.processorId}_${taskId.index}"
+  private val metricName = s"app${appId}.processor${taskId.processorId}task${taskId.index}"
   private val receiveLatency = Metrics(context.system).histogram(s"$metricName.receiveLatency")
   private val processTime = Metrics(context.system).histogram(s"$metricName.processTime")
   private val sendThroughput = Metrics(context.system).meter(s"$metricName.sendThroughput")

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/StreamingTestUtil.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/StreamingTestUtil.scala
@@ -50,8 +50,8 @@ object StreamingTestUtil {
     val masterConf = AppMasterContext(appId, testUserName, Resource(1),  None,miniCluster.mockMaster,AppMasterRuntimeInfo(appId, appName = appId.toString))
 
     val props = Props(new AppMaster(masterConf, AppDescription("test", UserConfig.empty, Graph.empty)))
-    val registerAppMaster = RegisterAppMaster(miniCluster.mockMaster, masterConf.registerData)
     val appMaster = miniCluster.launchActor(props).asInstanceOf[TestActorRef[AppMaster]]
+    val registerAppMaster = RegisterAppMaster(appMaster, masterConf.registerData)
     miniCluster.mockMaster.tell(registerAppMaster, appMaster)
 
     appMaster

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/HistoryMetricsServiceSpec.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/HistoryMetricsServiceSpec.scala
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.appmaster
+
+import akka.actor.{Props, ActorSystem}
+import akka.testkit.TestProbe
+import org.apache.gearpump.cluster.ClientToMaster.QueryHistoryMetrics
+import org.apache.gearpump.cluster.MasterToClient.{HistoryMetrics, HistoryMetricsItem}
+import org.apache.gearpump.metrics.Metrics.{Histogram, Meter, Counter}
+import org.apache.gearpump.streaming.appmaster.HistoryMetricsService._
+import org.scalatest.{BeforeAndAfterEach, Matchers, FlatSpec}
+
+class HistoryMetricsServiceSpec  extends FlatSpec with Matchers with BeforeAndAfterEach {
+
+  val count = 2
+  val intervalMs = 10
+
+  val config = HistoryMetricsConfig(
+    retainHistoryDataHours = 72,
+    retainHistoryDataIntervalMs = 3600 * 1000,
+    retainRecentDataSeconds = 300,
+    retainRecentDataIntervalMs = 15 * 1000)
+
+  "SingleValueMetricsStore" should "retain metrics and expire old value" in {
+
+    val store = new SingleValueMetricsStore(count, intervalMs)
+
+    //only 1 data point will be kept in @intervalMs
+    store.add(Counter("count", 1))
+    store.add(Counter("count", 2))
+
+    //sleep @intervalMs + 1 so that we are allowed to push new data
+    Thread.sleep(intervalMs + 1)
+
+    //only 1 data point will be kept in @intervalMs
+    store.add(Counter("count", 3))
+    store.add(Counter("count", 4))
+
+    //sleep @intervalMs + 1 so that we are allowed to push new data
+    Thread.sleep(intervalMs + 1)
+
+    //only 1 data point will be kept in @intervalMs
+    //expire oldest data point, because we only keep @count records
+    store.add(Counter("count", 5))
+    store.add(Counter("count", 6))
+
+    val result = store.read
+    assert(result.size == count)
+
+    //the oldest value is expired
+    assert(result.head.value.asInstanceOf[Counter].value == 3L)
+
+    //the newest value is inserted
+    assert(result.last.value.asInstanceOf[Counter].value == 5L)
+  }
+
+  val meterTemplate = Meter("meter", 0, 0, 0, 0, 0, "s")
+
+  "MinMaxMetricsStore" should "retain min and max metrics data and expire old value" in {
+
+    val compartor = (left: HistoryMetricsItem, right: HistoryMetricsItem) =>
+      left.value.asInstanceOf[Meter].meanRate > right.value.asInstanceOf[Meter].meanRate
+
+    val store = new MinMaxMetricsStore(count, intervalMs, compartor)
+
+    val min = 1
+    val max = 10
+
+    // only two data points will be kept in @intervalMs, one is the min, the other is the max
+    (min to max).foreach(num => store.add(meterTemplate.copy(name = "A", meanRate = num)))
+
+    //sleep @intervalMs + 1 so that we are allowed to push new data
+    Thread.sleep(intervalMs + 1)
+
+    // only two data points will be kept in @intervalMs, one is the min, the other is the max
+    (min to max).foreach(num => store.add(meterTemplate.copy(name = "B", meanRate = num)))
+
+    //sleep @intervalMs + 1 so that we are allowed to push new data
+    Thread.sleep(intervalMs + 1)
+
+    // only two data points will be kept in @intervalMs, one is the min, the other is the max
+    // also will expire the oldest data, because we only keep @count records
+    (min to max).foreach(num => store.add(meterTemplate.copy(name = "C", meanRate = num)))
+
+    val result = store.read
+    assert(result.size == count * 2)
+
+    //the oldest value A is expired
+    assert(result.head.value.asInstanceOf[Meter].name == "B")
+    //the first value is "B", min, the second first value is "B", "max"
+    assert(result.head.value.asInstanceOf[Meter].meanRate == min)
+
+    //the newest value C is expired
+    assert(result.last.value.asInstanceOf[Meter].name == "C")
+    //the last value is "C", max, the second last value is "C", "min"
+    assert(result.last.value.asInstanceOf[Meter].meanRate == max)
+
+  }
+
+  "HistogramMetricsStore" should "retain corse-grain history and fine-grain recent data" in {
+    val store = new HistogramMetricsStore(config)
+    store.add(Histogram(null, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+
+    //there should be 3 records, min-history, max-history, and recent
+    assert(store.read.size == 3)
+  }
+
+  "MeterMetricsStore" should "retain corse-grain history and fine-grain recent data" in {
+    val store = new MeterMetricsStore(config)
+    store.add(Meter(null, 0, 0, 0, 0, 0, null))
+
+    //there should be 3 records, min-history, max-history, and recent
+    assert(store.read.size == 3)
+  }
+
+  "CounterMetricsStore" should "retain corse-grain history and fine-grain recent data" in {
+    val store = new CounterMetricsStore(config)
+    store.add(Counter(null, 0))
+
+    //there should be 2 records, history, and recent
+    assert(store.read.size == 2)
+  }
+
+  "HistoryMetricsService" should "retain lastest metrics data and allow user to query metrics by path" in {
+    implicit val system = ActorSystem("test")
+    val appId = 0
+    val service = system.actorOf(Props(new HistoryMetricsService(0, config)))
+    service ! Counter("metric.counter", 0)
+    service ! Meter("metric.meter", 0, 0, 0, 0, 0, null)
+    service ! Histogram("metric.histogram", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+    val client = TestProbe()
+
+    // filter metrics with path "metric.counter"
+    client.send(service, QueryHistoryMetrics(appId, "metric.counter"))
+    import scala.concurrent.duration._
+    client.expectMsgPF(3 seconds) {
+      case history: HistoryMetrics =>
+        assert(history.appId == appId)
+        assert(history.path == "metric.counter")
+        val metricList = history.metrics
+        metricList.foreach(metricItem =>
+          assert(metricItem.value.isInstanceOf[Counter])
+        )
+    }
+
+    // filter metrics with path "metric.meter"
+    client.send(service, QueryHistoryMetrics(appId, "metric.meter"))
+    client.expectMsgPF(3 seconds) {
+      case history: HistoryMetrics =>
+        assert(history.appId == appId)
+        assert(history.path == "metric.meter")
+        val metricList = history.metrics
+        metricList.foreach(metricItem =>
+          assert(metricItem.value.isInstanceOf[Meter])
+        )
+    }
+
+    // filter metrics with path "metric.histogram"
+    client.send(service, QueryHistoryMetrics(appId, "metric.histogram"))
+    client.expectMsgPF(3 seconds) {
+      case history: HistoryMetrics =>
+        assert(history.appId == appId)
+        assert(history.path == "metric.histogram")
+        val metricList = history.metrics
+        metricList.foreach(metricItem =>
+          assert(metricItem.value.isInstanceOf[Histogram])
+        )
+    }
+
+    // filter metrics with path prefix "metric", all metrics which can
+    // match the path prefix will be retained.
+    client.send(service, QueryHistoryMetrics(appId, "metric"))
+    client.expectMsgPF(3 seconds) {
+      case history: HistoryMetrics =>
+        val metricList = history.metrics
+
+        var counterFound = false
+        var meterFound = false
+        var histogramFound = false
+
+        metricList.foreach(metricItem =>
+          metricItem.value match {
+            case v: Counter => counterFound = true
+            case v: Meter => meterFound = true
+            case v: Histogram => histogramFound = true
+            case _ => //skip
+          }
+        )
+
+        // All kinds of metric type are reserved.
+        assert(counterFound && meterFound && histogramFound)
+    }
+
+    system.shutdown()
+
+  }
+}


### PR DESCRIPTION
...ashboard can query and present the timecharts which allow user to browser by specifying a time window.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/572)
<!-- Reviewable:end -->
