### PR TITLE
fix #584, KafkaOffsetManager only stores one offset per timestamp

### DIFF
--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/KafkaOffsetManager.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/lib/KafkaOffsetManager.scala
@@ -47,8 +47,10 @@ private[kafka] class KafkaOffsetManager(storage: OffsetStorage) extends OffsetMa
 
   override def filter(messageAndOffset: (Message, Long)): Option[Message] = {
     val (message, offset) = messageAndOffset
-    maxTime = Math.max(maxTime, message.timestamp)
-    storage.append(maxTime, Injection[Long, Array[Byte]](offset))
+    if (message.timestamp > maxTime) {
+      maxTime = message.timestamp
+      storage.append(maxTime, Injection[Long, Array[Byte]](offset))
+    }
     Some(message)
   }
 


### PR DESCRIPTION
fix #584, KafkaOffsetManager only stores one offset per timestamp

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/585)
<!-- Reviewable:end -->
