### PR TITLE
fix #369 make task scheduler be aware of task locality

### DIFF
--- a/core/src/main/scala/org/apache/gearpump/cluster/UserConfig.scala
+++ b/core/src/main/scala/org/apache/gearpump/cluster/UserConfig.scala
@@ -26,7 +26,6 @@ import com.google.common.io.BaseEncoding
  * Immutable configuration
  */
 final class UserConfig(private val _config: Map[String, String])  extends Serializable{
-import org.apache.gearpump.cluster.UserConfig._
 
   def withInt(key: String, value: Int) : UserConfig = {
     new UserConfig(_config + (key -> value.toString))

--- a/core/src/main/scala/org/apache/gearpump/serializer/GearpumpSerialization.scala
+++ b/core/src/main/scala/org/apache/gearpump/serializer/GearpumpSerialization.scala
@@ -23,13 +23,15 @@ import com.typesafe.config.Config
 import org.apache.gearpump.util.{Constants, LogUtil}
 import org.slf4j.Logger
 
+import org.apache.gearpump.util.Util
+
 class GearpumpSerialization(config: Config) {
 
   private val LOG: Logger = LogUtil.getLogger(getClass)
 
   def customize(kryo: Kryo): Unit  = {
 
-    val serializationMap = configToMap(config, Constants.GEARPUMP_SERIALIZERS)
+    val serializationMap = Util.configToMap(config, Constants.GEARPUMP_SERIALIZERS)
 
     serializationMap.foreach { kv =>
       val (key, value) = kv
@@ -46,10 +48,5 @@ class GearpumpSerialization(config: Config) {
       }
     }
     kryo.setReferences(false)
-  }
-
-  private final def configToMap(config : Config, path: String) = {
-    import scala.collection.JavaConverters._
-    config.getConfig(path).root.unwrapped.asScala.toMap map { case (k, v) ⇒ k -> v.toString }
   }
 }

--- a/core/src/main/scala/org/apache/gearpump/util/Util.scala
+++ b/core/src/main/scala/org/apache/gearpump/util/Util.scala
@@ -33,9 +33,14 @@ import scala.util.Try
 object Util {
   val LOG = LogUtil.getLogger(getClass)
   private val appNamePattern = "^[a-zA-Z_][a-zA-Z0-9_]+$".r.pattern
+  private val validIpAddressRegex = "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)".r
 
   def validApplicationName(appName: String): Boolean = {
     appNamePattern.matcher(appName).matches()
+  }
+
+  def parseIp(path: String): Option[String] = {
+    validIpAddressRegex.findFirstIn(path)
   }
 
   def getCurrentClassPath : Array[String] = {
@@ -114,5 +119,10 @@ object Util {
       val decoded = BaseEncoding.base64().decode(base64)
       SerializationUtils.deserialize(decoded).asInstanceOf[T]
     }.toOption
+  }
+
+  def configToMap(config : Config, path: String) = {
+    import scala.collection.JavaConverters._
+    config.getConfig(path).root.unwrapped.asScala.toMap map { case (k, v) ⇒ k -> v.toString }
   }
 }

--- a/core/src/test/scala/org/apache/gearpump/util/UtilSpec.scala
+++ b/core/src/test/scala/org/apache/gearpump/util/UtilSpec.scala
@@ -42,4 +42,12 @@ class UtilSpec extends FlatSpec with Matchers with MockitoSugar {
     assert(!Util.validApplicationName("0_application_1"))
     assert(!Util.validApplicationName("_applicat&&ion_1"))
   }
+
+  it should "parse the ip address from the given path" in {
+    assert(Util.parseIp("this is a test") == None)
+    assert(Util.parseIp("this is a test 999.999.999.999") == None)
+    assert(Util.parseIp("this is a test 127.0.0.1:1024") == Some("127.0.0.1"))
+    assert(Util.parseIp("this is a test 255.255.255.255:1024") == Some("255.255.255.255"))
+    assert(Util.parseIp("this is a test 192.168.10.132:1024") == Some("192.168.10.132"))
+  }
 }

--- a/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/KafkaDataDetector.scala
+++ b/external/kafka/src/main/scala/org/apache/gearpump/streaming/kafka/KafkaDataDetector.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gearpump.streaming.kafka
+
+import java.net.InetAddress
+
+import akka.actor.ActorSystem
+import kafka.utils.ZkUtils
+import org.I0Itec.zkclient.ZkClient
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.appmaster.DataDetector
+import org.apache.gearpump.streaming.kafka.lib.{KafkaUtil, KafkaConfig}
+
+class KafkaDataDetector extends DataDetector {
+  private var taskNumOnHosts = Map.empty[String, Int]
+
+  override def init(config: UserConfig)(implicit actorSystem: ActorSystem): Unit = {
+    val kafkaConfig = config.getValue[KafkaConfig](KafkaConfig.NAME).get
+    val zkClient = KafkaUtil.connectZookeeper(kafkaConfig)
+    val topic = kafkaConfig.getConsumerTopics
+    val topicAndPartitions = ZkUtils.getPartitionsForTopics(zkClient, topic)
+    topicAndPartitions.foreach{ kv =>
+      val (topic, partitions) = kv
+      partitions.foreach{ partitionId =>
+        val ip = getHostIPForPartition(zkClient, topic, partitionId)
+        val taskNums = taskNumOnHosts.getOrElse(ip, 0) + 1
+        taskNumOnHosts += ip -> taskNums
+      }
+    }
+  }
+
+  override def getTaskNumOnHosts(): Map[String, Int] = taskNumOnHosts
+
+  private def getHostIPForPartition(zkClient: ZkClient, topic: String, partition: Int): String = {
+    val leader = ZkUtils.getLeaderForPartition(zkClient, topic, partition)
+      .getOrElse(throw new RuntimeException(s"leader not available for TopicAndPartition($topic, $partition)"))
+    val broker = ZkUtils.getBrokerInfo(zkClient, leader)
+      .getOrElse(throw new RuntimeException(s"broker info not found for leader $leader"))
+    InetAddress.getByName(broker.host).getHostAddress
+  }
+}

--- a/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/KafkaDataDetectorSpec.scala
+++ b/external/kafka/src/test/scala/org/apache/gearpump/streaming/kafka/KafkaDataDetectorSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gearpump.streaming.kafka
+
+import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
+import kafka.utils.{TestZKUtils, TestUtils => TestKafkaUtils}
+import kafka.server.{KafkaConfig => KafkaServerConfig}
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.kafka.lib.KafkaConfig
+import org.apache.gearpump.streaming.kafka.util.KafkaServerHarness
+import org.scalatest.{BeforeAndAfterEach, Matchers, PropSpec}
+import org.scalatest.prop.PropertyChecks
+
+import scala.collection.JavaConverters._
+
+class KafkaDataDetectorSpec extends PropSpec with PropertyChecks with Matchers with BeforeAndAfterEach with KafkaServerHarness {
+  val numServers = 1
+  implicit var system1: ActorSystem = null
+  override val configs: List[KafkaServerConfig] = {
+    for (props <- TestKafkaUtils.createBrokerConfigs(numServers, enableControlledShutdown = false))
+    yield new KafkaServerConfig(props) {
+      override val zkConnect = TestZKUtils.zookeeperConnect
+      override val numPartitions = 1
+    }
+  }
+
+  override def beforeEach(): Unit = {
+    super.setUp()
+    system1 = ActorSystem("KafkaDataDetector")
+  }
+
+  override def afterEach(): Unit = {
+    super.tearDown()
+    system1.shutdown()
+  }
+
+  property("KafkaDataDetector should return corrent partition num on each host") {
+    val partitionNum = 3
+    val topic = TestKafkaUtils.tempTopic()
+    val brokerList = getBrokerList.mkString(",")
+    createTopicUntilLeaderIsElected(topic, partitions = partitionNum, replicas = 1)
+
+    val kafkaConfig = getKafkaConfig(topic, brokerList, zkConnect)
+    val kafkaDataConnector = new KafkaDataDetector()
+    kafkaDataConnector.init(kafkaConfig)
+    val taskNumOnHosts = kafkaDataConnector.getTaskNumOnHosts()
+    assert(taskNumOnHosts.size == 1)
+    assert(taskNumOnHosts.contains("127.0.0.1"))
+    assert(taskNumOnHosts.get("127.0.0.1").get == 3)
+  }
+
+  private def getKafkaConfig(consumerTopic: String, brokerList: String, zookeeperConnect: String): UserConfig = {
+    UserConfig.empty.withValue[KafkaConfig](KafkaConfig.NAME, KafkaConfig(ConfigFactory.parseMap(Map(
+      KafkaConfig.CONSUMER_TOPICS -> consumerTopic,
+      KafkaConfig.PRODUCER_BOOTSTRAP_SERVERS -> brokerList,
+      KafkaConfig.SOCKET_TIMEOUT_MS -> "1000000",
+      KafkaConfig.ZOOKEEPER_CONNECT -> zookeeperConnect
+    ).asJava)))
+  }
+}

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/DataDetector.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/DataDetector.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gearpump.streaming.appmaster
+
+import akka.actor.ActorSystem
+import org.apache.gearpump.cluster.UserConfig
+
+trait DataDetector {
+  def init(config: UserConfig)(implicit actorSystem: ActorSystem)
+
+  /**
+   *  This function will return the Map contains:
+   *    key: IP of host
+   *    value: the task number that user want to launch on this host
+   */
+  def getTaskNumOnHosts(): Map[String, Int]
+}

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/ScheduleUsingUserConfig.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/ScheduleUsingUserConfig.scala
@@ -23,13 +23,13 @@ import akka.actor.Actor
 import com.typesafe.config.Config
 import org.apache.gearpump.cluster.ClusterConfig
 import org.apache.gearpump.streaming.TaskDescription
-import org.apache.gearpump.streaming.appmaster.TaskLocator.{WorkerLocality, NonLocality, Locality}
+import org.apache.gearpump.streaming.appmaster.ScheduleUsingUserConfig.{WorkerLocality, NonLocality, Locality}
 import org.apache.gearpump.streaming.task.{Task, TaskUtil}
 import org.apache.gearpump.util.{ActorUtil, Constants}
 
 import scala.collection.mutable
 
-class TaskLocator(config: Config) {
+class ScheduleUsingUserConfig(config: Config) extends TaskSchedulePolicy{
   private var userScheduledTask = Map.empty[Class[_ <: Task], mutable.Queue[Locality]]
 
   initTasks()
@@ -44,7 +44,7 @@ class TaskLocator(config: Config) {
     }
   }
 
-  def locateTask(taskDescription : TaskDescription) : Locality = {
+  def scheduleTask(taskDescription : TaskDescription) : Locality = {
     if(userScheduledTask.contains(TaskUtil.loadClass(taskDescription.taskClass))){
       val localityQueue = userScheduledTask.get(TaskUtil.loadClass(taskDescription.taskClass)).get
       if(localityQueue.size > 0){
@@ -87,7 +87,7 @@ gearpump {
   }
 }
 
-object TaskLocator {
+object ScheduleUsingUserConfig {
 
   trait Locality
 

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/TaskManager.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/TaskManager.scala
@@ -20,7 +20,9 @@ package org.apache.gearpump.streaming.appmaster
 
 import akka.actor._
 import akka.pattern.ask
-import org.apache.gearpump.cluster.MasterToAppMaster.ReplayFromTimestampWindowTrailingEdge
+import org.apache.gearpump.cluster.AppMasterToMaster.{WorkerData, GetWorkerData, GetAllWorkers}
+import org.apache.gearpump.cluster.MasterToAppMaster.{WorkerList, ReplayFromTimestampWindowTrailingEdge}
+import org.apache.gearpump.cluster.UserConfig
 import org.apache.gearpump.cluster.scheduler.Resource
 import org.apache.gearpump.streaming.AppMasterToExecutor.{LaunchTask, StartClock}
 import org.apache.gearpump.streaming.executor.{ExecutorRestartPolicy, Executor}
@@ -31,7 +33,7 @@ import org.apache.gearpump.streaming.appmaster.ExecutorManager._
 import org.apache.gearpump.streaming.appmaster.TaskSchedulerImpl.TaskLaunchData
 import org.apache.gearpump.streaming.task._
 import org.apache.gearpump.streaming.DAG
-import org.apache.gearpump.util.{Constants, LogUtil}
+import org.apache.gearpump.util.{Constants, LogUtil, Util}
 import org.slf4j.Logger
 
 import scala.concurrent.Future
@@ -57,7 +59,6 @@ private[appmaster] class TaskManager(
   import context.dispatcher
 
   startWith(Uninitialized, null)
-  self ! DagInit(dag)
 
   when (Uninitialized) {
     case Event(DagInit(dag), _) =>

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/TaskSchedulePolicy.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/appmaster/TaskSchedulePolicy.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.gearpump.streaming.appmaster
+
+import akka.actor.ActorSystem
+import com.typesafe.config.Config
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.TaskDescription
+import org.apache.gearpump.streaming.appmaster.ScheduleUsingUserConfig.{WorkerLocality, NonLocality, Locality}
+import org.apache.gearpump.streaming.task.{TaskUtil, Task}
+import org.apache.gearpump.util.Util
+
+import scala.collection.mutable
+
+trait TaskSchedulePolicy {
+  def scheduleTask(taskDescription: TaskDescription) : Locality
+}
+
+class NoneSchedulePolicy extends TaskSchedulePolicy {
+  override def scheduleTask(taskDescription: TaskDescription): Locality = NonLocality
+}
+
+class ScheduleUsingDataDetector(systemConfig: Config, userConfig: UserConfig, workers: Map[String, Set[Int]], system: ActorSystem) extends TaskSchedulePolicy {
+  private var userScheduledTask = Map.empty[Class[_ <: Task], mutable.Queue[Locality]]
+  private var dataConnectors = Map.empty[String, DataDetector]
+
+  init()
+
+  def init(): Unit = {
+    initDataDetectors(systemConfig)
+    dataConnectors.foreach { kv =>
+      val (task, dataDetector) = kv
+      val taskClass = TaskUtil.loadClass(task)
+      val localities = userScheduledTask.getOrElse(taskClass, mutable.Queue.empty[Locality])
+      val tasksOnHost = dataDetector.getTaskNumOnHosts()
+      tasksOnHost.foreach { ipAndTaskNum =>
+        val (ip, taskNum) = ipAndTaskNum
+        0.until(taskNum).foreach(_ => localities.enqueue(translateIpToLocality(ip)))
+      }
+      userScheduledTask += taskClass -> localities
+    }
+  }
+
+  override def scheduleTask(taskDescription: TaskDescription): Locality = {
+    if(userScheduledTask.contains(TaskUtil.loadClass(taskDescription.taskClass))){
+      val localityQueue = userScheduledTask.get(TaskUtil.loadClass(taskDescription.taskClass)).get
+      if(localityQueue.size > 0){
+        return localityQueue.dequeue()
+      }
+    }
+    NonLocality
+  }
+
+  /*
+  gearpump {
+    application {
+      data {
+        detector {
+          task1 = dataconnector1
+          task2 = dataconnector2
+        }
+      }
+    }
+  }
+  */
+  def initDataDetectors(config: Config): Unit = {
+    if(config.hasPath(ScheduleUsingDataDetector.POLICY)) {
+      val taskLocatorMap = Util.configToMap(config, ScheduleUsingDataDetector.POLICY)
+      taskLocatorMap.foreach { kv =>
+        val (task, dataDetectorClass) = kv
+        val dataDetector = Class.forName(dataDetectorClass).newInstance().asInstanceOf[DataDetector]
+        dataDetector.init(userConfig)(system)
+        dataConnectors += task -> dataDetector
+      }
+    }
+  }
+
+  private def translateIpToLocality(ip: String): Locality = {
+    if(workers.contains(ip)){
+      WorkerLocality(workers.get(ip).get.head)
+    } else {
+      NonLocality
+    }
+  }
+}
+
+object ScheduleUsingDataDetector {
+  final val POLICY = "gearpump.application.data.detector"
+}

--- a/streaming/src/test/resources/tasklocation.conf
+++ b/streaming/src/test/resources/tasklocation.conf
@@ -10,5 +10,14 @@ gearpump {
       }
     }
   }
+  application {
+    data {
+      locator{
+        policies {
+          "task1" = "org.apache.gearpump.streaming.appmaster.Test"
+        }
+      }
+    }
+  }
 }
 

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/ScheduleUsingUserConfigSpec.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/ScheduleUsingUserConfigSpec.scala
@@ -20,14 +20,14 @@ package org.apache.gearpump.streaming.appmaster
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.{ClusterConfig, UserConfig}
 import org.apache.gearpump.streaming.TaskDescription
-import org.apache.gearpump.streaming.appmaster.TaskLocator.{NonLocality, WorkerLocality}
+import org.apache.gearpump.streaming.appmaster.ScheduleUsingUserConfig.{NonLocality, WorkerLocality}
 import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
 import org.apache.gearpump.util.Constants._
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.collection.mutable.ArrayBuffer
 
-class TaskLocatorSpec extends WordSpec with Matchers {
+class ScheduleUsingUserConfigSpec extends WordSpec with Matchers {
   val resource = getClass.getClassLoader.getResource("tasklocation.conf").getPath
   System.setProperty(GEARPUMP_CUSTOM_CONFIG_FILE, resource)
   val taskDescription1 = TaskDescription("org.apache.gearpump.streaming.appmaster.TestTask1", 4)
@@ -36,23 +36,23 @@ class TaskLocatorSpec extends WordSpec with Matchers {
 
   val config = ClusterConfig.load.application
 
-  "TaskLocator" should {
+  "ScheduleUsingUserConfig" should {
     "locate task properly according user's configuration" in {
-      val taskLocator = new TaskLocator(config)
-      assert(taskLocator.locateTask(taskDescription2) == WorkerLocality(1))
-      assert(taskLocator.locateTask(taskDescription2) == WorkerLocality(1))
-      assert(taskLocator.locateTask(taskDescription2) == NonLocality)
+      val taskLocator = new ScheduleUsingUserConfig(config)
+      assert(taskLocator.scheduleTask(taskDescription2) == WorkerLocality(1))
+      assert(taskLocator.scheduleTask(taskDescription2) == WorkerLocality(1))
+      assert(taskLocator.scheduleTask(taskDescription2) == NonLocality)
       val localities = ArrayBuffer[WorkerLocality]()
       for (i <- 0 until 4) {
-        localities.append(taskLocator.locateTask(taskDescription1).asInstanceOf[WorkerLocality])
+        localities.append(taskLocator.scheduleTask(taskDescription1).asInstanceOf[WorkerLocality])
       }
       localities.sortBy(_.workerId)
       assert(localities(0) == WorkerLocality(2))
       assert(localities(1) == WorkerLocality(2))
       assert(localities(2) == WorkerLocality(1))
       assert(localities(3) == WorkerLocality(1))
-      assert(taskLocator.locateTask(taskDescription1) == NonLocality)
-      assert(taskLocator.locateTask(taskDescription3) == NonLocality)
+      assert(taskLocator.scheduleTask(taskDescription1) == NonLocality)
+      assert(taskLocator.scheduleTask(taskDescription3) == NonLocality)
     }
   }
 }

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/TaskManagerSpec.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/TaskManagerSpec.scala
@@ -30,7 +30,7 @@ import Executor.RestartExecutor
 import org.apache.gearpump.streaming.ExecutorToAppMaster.RegisterTask
 import org.apache.gearpump.streaming.appmaster.AppMaster.AllocateResourceTimeOut
 import org.apache.gearpump.streaming.appmaster.ExecutorManager._
-import org.apache.gearpump.streaming.appmaster.TaskManager.MessageLoss
+import org.apache.gearpump.streaming.appmaster.TaskManager.{DagInit, MessageLoss}
 import org.apache.gearpump.streaming.appmaster.TaskManagerSpec.{Env, Task1, Task2}
 import org.apache.gearpump.streaming.appmaster.TaskSchedulerImpl.TaskLaunchData
 import org.apache.gearpump.streaming.task._
@@ -130,6 +130,7 @@ class TaskManagerSpec extends FlatSpec with Matchers with BeforeAndAfterEach {
     val taskManager = system.actorOf(
       Props(new TaskManager(appId, dag, scheduler, executorManager.ref, clockService.ref, appMaster.ref, "appName")))
 
+    taskManager ! DagInit(dag)
     // taskmanager should return the latest clock to task(0,0)
     clockService.expectMsg(GetLatestMinClock)
     clockService.reply(LatestMinClock(0))

--- a/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/TaskSchedulerSpec.scala
+++ b/streaming/src/test/scala/org/apache/gearpump/streaming/appmaster/TaskSchedulerSpec.scala
@@ -40,8 +40,8 @@ class TaskSchedulerSpec extends WordSpec with Matchers {
 
   "TaskScheduler" should {
     "schedule tasks on different workers properly according user's configuration" in {
-      val taskScheduler = new TaskSchedulerImpl(appId = 0, config)
-
+      val taskScheduler = new TaskSchedulerImpl(appId = 0)
+      taskScheduler.updateTaskSchedulePolicy(new ScheduleUsingUserConfig(config))
       val expectedRequests =
         Array( ResourceRequest(Resource(4), 1, relaxation = Relaxation.SPECIFICWORKER),
           ResourceRequest(Resource(2), 2, relaxation = Relaxation.SPECIFICWORKER))


### PR DESCRIPTION
This pull request is a half-done PR because further discussion is needed.
For data locality awareness, there are some complicated situation:
 1. One streaming application needs to read data from different data sources, like HDFS, Kafka etc.
 2. Also, one streaming application can read different topics from Kafka.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/619)
<!-- Reviewable:end -->
