### PR TITLE
fix #415, support storm over gearpump

### DIFF
--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/GearpumpNimbus.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/GearpumpNimbus.scala
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm
+
+import java.nio.ByteBuffer
+
+import backtype.storm.generated._
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.cluster.client.ClientContext
+import org.apache.gearpump.experiments.storm.util.GraphBuilder
+import org.apache.gearpump.streaming.AppDescription
+import org.apache.gearpump.util.LogUtil
+
+import scala.collection.JavaConverters._
+
+class GearpumpNimbus(clientContext: ClientContext) extends Nimbus.Iface {
+  private var applications = Map.empty[String, Int]
+  private var topologies = Map.empty[String, StormTopology]
+  private val LOG = LogUtil.getLogger(classOf[GearpumpNimbus])
+
+  override def submitTopology(name: String, uploadedJarLocation: String, jsonConf: String, topology: StormTopology): Unit =
+    submitTopologyWithOpts(name, uploadedJarLocation, jsonConf, topology, new SubmitOptions(TopologyInitialStatus.ACTIVE))
+
+  override def killTopologyWithOpts(name: String, options: KillOptions): Unit = {
+    topologies -= name
+    clientContext.shutdown(applications.getOrElse(name, throw new RuntimeException(s"topology $name not found")))
+    LOG.info(s"Killed topology $name")
+  }
+
+  override def submitTopologyWithOpts(name: String, uploadedJarLocation: String, jsonConf: String, topology: StormTopology, options: SubmitOptions): Unit = {
+    import org.apache.gearpump.experiments.storm.util.StormUtil._
+    topologies += name -> topology
+    val builder = GraphBuilder(topology)
+    builder.build()
+    val processorGraph = builder.getProcessorGraph
+    val processorToComponent = builder.getProcessorToComponent
+    implicit val system = clientContext.system
+    val config = UserConfig.empty
+      .withValue[StormTopology](TOPOLOGY, topology)
+      .withValue[List[(Int, String)]](PROCESSOR_TO_COMPONENT, processorToComponent.toList)
+      .withValue[String](STORM_CONFIG, jsonConf)
+    val app = AppDescription("storm", config, processorGraph)
+    val appId = clientContext.submit(app)
+
+    applications += name -> appId
+
+    LOG.info(s"Submitted application $appId")
+  }
+
+  override def uploadChunk(location: String, chunk: ByteBuffer): Unit = {
+  }
+
+  override def getNimbusConf: String = {
+    throw new UnsupportedOperationException
+  }
+
+  override def getTopology(id: String): StormTopology = topologies(id)
+
+  override def getTopologyConf(id: String): String = {
+    throw new UnsupportedOperationException
+  }
+
+  override def beginFileDownload(file: String): String = {
+    throw new UnsupportedOperationException
+  }
+
+  override def getUserTopology(id: String): StormTopology = getTopology(id)
+
+  override def activate(name: String): Unit = {
+    throw new UnsupportedOperationException
+  }
+
+  override def rebalance(name: String, options: RebalanceOptions): Unit = {
+    throw new UnsupportedOperationException
+  }
+
+  override def deactivate(name: String): Unit = {
+    throw new UnsupportedOperationException
+  }
+
+  override def getTopologyInfo(id: String): TopologyInfo = {
+    throw new UnsupportedOperationException
+  }
+
+  override def killTopology(name: String): Unit = killTopologyWithOpts(name, new KillOptions())
+
+  override def downloadChunk(id: String): ByteBuffer = {
+    throw new UnsupportedOperationException
+  }
+
+  override def beginFileUpload(): String = {
+    "local thrift server"
+  }
+
+  override def getClusterInfo: ClusterSummary = {
+    val topologySummaryList = topologies.map { case (name, _) =>
+      new TopologySummary(name, name, 0, 0, 0, 0, "")
+    }.toSeq
+    new ClusterSummary(List[SupervisorSummary]().asJava, 0, topologySummaryList.asJava)
+  }
+
+  override def finishFileUpload(location: String): Unit = {
+  }
+}

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/GearpumpThriftServer.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/GearpumpThriftServer.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm
+
+import backtype.storm.generated.Nimbus
+import org.apache.gearpump.cluster.client.ClientContext
+import org.apache.thrift7.protocol.TBinaryProtocol
+import org.apache.thrift7.server.{THsHaServer, TServer}
+import org.apache.thrift7.transport.TNonblockingServerSocket
+
+object GearpumpThriftServer {
+  val THRIFT_PORT = 6627
+  val THRIFT_THREADS = 64
+  val THRIFT_MAX_BUFFER_SIZE = 1048576
+
+  def apply(clientContext: ClientContext): GearpumpThriftServer = new GearpumpThriftServer(clientContext)
+}
+
+class GearpumpThriftServer(clientContext: ClientContext) extends Thread {
+  import org.apache.gearpump.experiments.storm.GearpumpThriftServer._
+
+  private val server: TServer = createServer
+
+  override def run(): Unit = {
+    server.serve()
+  }
+
+  private def createServer: TServer = {
+    val serverTransport = new TNonblockingServerSocket(THRIFT_PORT)
+    val args = new THsHaServer.Args(serverTransport)
+    args.workerThreads(THRIFT_THREADS)
+      .protocolFactory(new TBinaryProtocol.Factory(false, true, THRIFT_MAX_BUFFER_SIZE))
+      .processor(new Nimbus.Processor[GearpumpNimbus](new GearpumpNimbus(clientContext)))
+    new THsHaServer(args)
+  }
+
+  def close(): Unit = {
+    server.stop()
+  }
+
+}

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/StormRunner.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/StormRunner.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm
+
+import backtype.storm.Config
+import org.apache.gearpump.cluster.client.ClientContext
+import org.apache.gearpump.cluster.main.{CLIOption, ArgumentsParser}
+import org.apache.gearpump.util.{Constants, Util}
+
+
+object StormRunner extends App with ArgumentsParser {
+  override val options: Array[(String, CLIOption[Any])] = Array(
+    "master" -> CLIOption[String]("<host1:port1,host2:port2,host3:port3>", required = true),
+    "storm_topology" -> CLIOption[String]("<storm topology main class>", required = true),
+    "storm_args" -> CLIOption[String]("<storm topology name>", required = false),
+    "runseconds"-> CLIOption[Int]("<how long to run this example>", required = false, defaultValue = Some(60)))
+
+  val config = parse(args)
+
+  val clientContext = ClientContext(config.getString("master"))
+  val thriftServer = GearpumpThriftServer(clientContext)
+  thriftServer.start()
+
+  val topologyClass = config.getString("storm_topology")
+  val stormArgs = config.getString("storm_args")
+  val stormOptions = Array("-Dstorm.options=" +
+    s"${Config.NIMBUS_HOST}=127.0.0.1,${Config.NIMBUS_THRIFT_PORT}=${GearpumpThriftServer.THRIFT_PORT}",
+    "-Dstorm.jar=" + System.getProperty(Constants.GEARPUMP_APP_JAR)
+  )
+
+  val classPath = Array(System.getProperty("java.class.path"))
+  val arguments = stormArgs.split(",")
+  Util.startProcess(stormOptions, classPath, topologyClass, arguments)
+
+  Thread.sleep(config.getInt("runseconds") * 1000)
+  thriftServer.close()
+  clientContext.close()
+}

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/partitioner/FieldsGroupingPartitioner.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/partitioner/FieldsGroupingPartitioner.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.partitioner
+
+import backtype.storm.tuple.Fields
+import org.apache.gearpump.Message
+import org.apache.gearpump.experiments.storm.util.StormTuple
+import org.apache.gearpump.partitioner.Partitioner
+import scala.collection.JavaConverters._
+
+
+private[storm] class FieldsGroupingPartitioner(outFields: Fields, groupFields: Fields) extends Partitioner {
+  override def getPartition(msg: Message, partitionNum: Int): Int = {
+    val values = msg.msg.asInstanceOf[StormTuple].values
+    val hash = outFields.select(groupFields, values.asJava).hashCode()
+    hash % partitionNum
+  }
+}

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/partitioner/GlobalGroupingPartitioner.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/partitioner/GlobalGroupingPartitioner.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.partitioner
+
+import org.apache.gearpump.Message
+import org.apache.gearpump.partitioner.Partitioner
+
+private[storm] class GlobalGroupingPartitioner extends Partitioner {
+  override def getPartition(msg: Message, partitionNum: Int): Int = 0
+}

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/partitioner/NoneGroupingPartitioner.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/partitioner/NoneGroupingPartitioner.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.partitioner
+
+import org.apache.gearpump.Message
+import org.apache.gearpump.partitioner.Partitioner
+
+import scala.util.Random
+
+class NoneGroupingPartitioner extends Partitioner {
+  override def getPartition(msg: Message, partitionNum: Int): Int = {
+    val random = new Random
+    random.nextInt % partitionNum
+  }
+}

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/partitioner/ShuffleGroupingPartitioner.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/partitioner/ShuffleGroupingPartitioner.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.partitioner
+
+import org.apache.gearpump.Message
+import org.apache.gearpump.partitioner.Partitioner
+
+import scala.util.Random
+
+class ShuffleGroupingPartitioner extends Partitioner {
+  override def getPartition(msg: Message, partitionNum: Int): Int = {
+    val random = new Random
+    random.shuffle(0.until(partitionNum).toList).head
+  }
+}

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/processor/StormBoltOutputCollector.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/processor/StormBoltOutputCollector.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.processor
+
+import java.util.{Collection => JCollection, List => JList}
+
+import backtype.storm.task.IOutputCollector
+import backtype.storm.tuple.Tuple
+import org.apache.gearpump.Message
+import org.apache.gearpump.experiments.storm.util.StormTuple
+import org.apache.gearpump.streaming.task.TaskContext
+
+import scala.collection.JavaConversions._
+
+private[storm] class StormBoltOutputCollector(pid: Int, taskContext: TaskContext) extends IOutputCollector {
+  import taskContext.output
+
+  override def emit(streamId: String, anchors: JCollection[Tuple], tuple: JList[AnyRef]): JList[Integer] = {
+    output(Message(StormTuple(tuple.toList, pid, streamId)))
+    null
+  }
+
+  override def emitDirect(i: Int, s: String, collection: JCollection[Tuple], list: JList[AnyRef]): Unit = {
+    throw new RuntimeException("emit direct not supported")
+  }
+
+  override def fail(tuple: Tuple): Unit = {}
+
+  override def ack(tuple: Tuple): Unit = {}
+
+  override def reportError(throwable: Throwable): Unit = {
+    throw throwable
+  }
+}

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/processor/StormProcessor.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/processor/StormProcessor.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.processor
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.Cancellable
+import backtype.storm.task.{IBolt, OutputCollector}
+import backtype.storm.tuple.TupleImpl
+import backtype.storm.utils.Utils
+import org.apache.gearpump.Message
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.experiments.storm.util.StormTuple
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
+import scala.collection.JavaConversions._
+
+import scala.concurrent.duration.FiniteDuration
+
+private[storm] class StormProcessor (taskContext : TaskContext, conf: UserConfig)
+  extends Task(taskContext, conf) {
+  import org.apache.gearpump.experiments.storm.util.StormUtil._
+
+  private val topology = getTopology(conf)
+  private val processorToComponent = getProcessorToComponent(conf)
+  private val stormConfig = getStormConfig(conf)
+  private val pid = taskContext.taskId.processorId
+  private val topologyContext = getTopologyContext(topology, stormConfig, processorToComponent, pid)
+  private val bolts = topology.get_bolts()
+  private val boltSpec = bolts.get(processorToComponent.getOrElse(pid,
+    throw new RuntimeException(s"processor $pid has no mapping component")))
+  private val bolt = Utils.getSetComponentObject(boltSpec.get_bolt_object()).asInstanceOf[IBolt]
+
+  private var count = 0
+  private var snapShotTime : Long = System.currentTimeMillis()
+  private var snapShotWordCount : Long = 0
+
+  private var scheduler : Cancellable = null
+
+  override def onStart(startTime: StartTime): Unit = {
+    val delegate = new StormBoltOutputCollector(pid, taskContext)
+    bolt.prepare(stormConfig, topologyContext, new OutputCollector(delegate))
+    scheduler = taskContext.schedule(new FiniteDuration(5, TimeUnit.SECONDS),
+      new FiniteDuration(5, TimeUnit.SECONDS))(reportWordCount)
+  }
+
+  override def onNext(msg: Message): Unit = {
+    val stormTuple = msg.msg.asInstanceOf[StormTuple]
+    val values = stormTuple.values
+    val taskId = stormTuple.sourceTaskId
+    val streamId = stormTuple.streamId
+    val tuple = new TupleImpl(topologyContext, values, taskId, streamId, null)
+    bolt.execute(tuple)
+    count += 1
+  }
+
+  private def reportWordCount() : Unit = {
+    val current : Long = System.currentTimeMillis()
+    LOG.info(s"Task ${taskContext.taskId} Throughput: ${(count - snapShotWordCount, (current - snapShotTime) / 1000)} (words, second)")
+    snapShotWordCount = count
+    snapShotTime = current
+  }
+
+}

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/producer/StormProducer.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/producer/StormProducer.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.producer
+
+import backtype.storm.spout.{ISpout, SpoutOutputCollector}
+import backtype.storm.utils.Utils
+import org.apache.gearpump.Message
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
+
+private[storm] class StormProducer(taskContext : TaskContext, conf: UserConfig)
+  extends Task(taskContext, conf) {
+  import org.apache.gearpump.experiments.storm.util.StormUtil._
+
+  private val topology = getTopology(conf)
+  private val processorToComponent = getProcessorToComponent(conf)
+  private val stormConfig = getStormConfig(conf)
+  private val pid = taskContext.taskId.processorId
+  private val topologyContext = getTopologyContext(topology, stormConfig, processorToComponent, pid)
+  private val spouts = topology.get_spouts()
+
+  private val spoutSpec = spouts.get(processorToComponent.getOrElse(pid,
+    throw new RuntimeException(s"processor $pid has no mapping component")))
+  private val spout = Utils.getSetComponentObject(spoutSpec.get_spout_object()).asInstanceOf[ISpout]
+
+  override def onStart(startTime: StartTime): Unit = {
+    val streamId = spoutSpec.get_common()
+    val delegate = new StormSpoutOutputCollector(pid, taskContext)
+    spout.open(stormConfig, topologyContext, new SpoutOutputCollector(delegate))
+    self ! Message("start")
+  }
+
+  override def onNext(msg: Message): Unit = {
+    spout.nextTuple()
+    self ! Message("Continue")
+  }
+}

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/producer/StormSpoutOutputCollector.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/producer/StormSpoutOutputCollector.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.producer
+
+import java.util.{List => JList}
+
+import backtype.storm.spout.ISpoutOutputCollector
+import org.apache.gearpump.Message
+import org.apache.gearpump.experiments.storm.util.StormTuple
+import org.apache.gearpump.streaming.task.TaskContext
+
+import scala.collection.JavaConverters._
+
+private[storm] class StormSpoutOutputCollector(pid: Int, taskContext: TaskContext) extends ISpoutOutputCollector {
+  import taskContext.output
+
+  override def emit(streamId: String, values: JList[AnyRef], messageId: scala.Any): JList[Integer] = {
+    val message = Message(StormTuple(values.asScala.toList, pid, streamId))
+    output(message)
+    null
+  }
+
+  override def reportError(throwable: Throwable): Unit = {
+    throw throwable
+  }
+
+  override def emitDirect(taskId: Int, streamId: String, values: JList[AnyRef], messageId: scala.Any): Unit = {
+    throw new RuntimeException("emit direct not supported")
+  }
+}

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/util/GraphBuilder.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/util/GraphBuilder.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.util
+
+import backtype.storm.generated.{Grouping, StormTopology}
+import backtype.storm.tuple.Fields
+import backtype.storm.utils.ThriftTopologyUtils
+import org.apache.gearpump.experiments.storm.partitioner.{NoneGroupingPartitioner, ShuffleGroupingPartitioner, FieldsGroupingPartitioner, GlobalGroupingPartitioner}
+import org.apache.gearpump.experiments.storm.processor.StormProcessor
+import org.apache.gearpump.experiments.storm.producer.StormProducer
+import org.apache.gearpump.partitioner.Partitioner
+import org.apache.gearpump.streaming.TaskDescription
+import org.apache.gearpump.util.Graph
+
+import scala.collection.JavaConversions._
+
+object GraphBuilder {
+  def apply(topology: StormTopology): GraphBuilder = new GraphBuilder(topology)
+}
+
+private[storm] class GraphBuilder(topology: StormTopology) {
+  private val componentGraph = Graph.empty[String, Grouping]
+  private val processorGraph = Graph.empty[TaskDescription, Partitioner]
+  private var processorToComponent = Map.empty[Int, String]
+  private var componentToProcessor = Map.empty[String, Int]
+
+  def build(): Unit = {
+    val spouts = topology.get_spouts()
+    val spoutTasks = spouts.map { spout =>
+      val parallelism = spout._2.get_common().get_parallelism_hint()
+      val taskDescription = TaskDescription(classOf[StormProducer].getName, parallelism)
+      spout._1 -> taskDescription
+    }
+    val bolts = topology.get_bolts()
+    val boltTasks = bolts.map { bolt =>
+      val parallelism = bolt._2.get_common().get_parallelism_hint()
+      val taskDescription = TaskDescription(classOf[StormProcessor].getName, parallelism)
+      bolt._1 -> taskDescription
+    }
+
+    spoutTasks.foreach { case (sourceId, sourceProducer) =>
+      val sourceSpec = spouts.get(sourceId)
+      getTargets(sourceId).foreach { case (streamId, targets) =>
+        val outFields = new Fields(sourceSpec.get_common().get_streams().get(streamId).get_output_fields())
+        targets.foreach { case (targetId, grouping) =>
+          boltTasks.get(targetId).foreach { targetProcessor =>
+            componentGraph.addEdge(sourceId, grouping, targetId)
+            processorGraph.addEdge(sourceProducer, groupingToPartitioner(outFields, grouping), targetProcessor)
+          }
+        }
+      }
+    }
+
+    boltTasks.foreach { case (sourceId, sourceProcessor) =>
+      val sourceSpec = bolts.get(sourceId)
+      getTargets(sourceId).foreach { case (streamId, targets) =>
+        val outFields = new Fields(sourceSpec.get_common().get_streams().get(streamId).get_output_fields())
+        targets.foreach { case (targetId, grouping) =>
+          boltTasks.get(targetId).foreach { targetProcessor =>
+            componentGraph.addEdge(sourceId, grouping, targetId)
+            processorGraph.addEdge(sourceProcessor, groupingToPartitioner(outFields, grouping), targetProcessor)
+          }
+        }
+      }
+    }
+
+    val topologyWithIndex = componentGraph.topologicalOrderIterator.zipWithIndex
+    componentToProcessor = topologyWithIndex.toMap
+    processorToComponent = componentToProcessor.map(entry => entry._2 -> entry._1)
+  }
+
+  def getProcessorGraph: Graph[TaskDescription, Partitioner] = processorGraph
+
+  def getProcessorToComponent: Map[Int, String] = processorToComponent
+
+  def getComponenToProcessor: Map[String, Int] = componentToProcessor
+
+  def getTargets(componentId: String): Map[String, Map[String, Grouping]] = {
+    val componentIds = ThriftTopologyUtils.getComponentIds(topology)
+    componentIds.flatMap { otherComponentId =>
+      ThriftTopologyUtils.getComponentCommon(topology, otherComponentId).get_inputs.toList.map(otherComponentId -> _)
+    }.foldLeft(Map.empty[String, Map[String, Grouping]]) {
+      (allTargets, componentAndInput) =>
+        val (otherComponentId, (globalStreamId, grouping)) = componentAndInput
+        val inputStreamId = globalStreamId.get_streamId()
+        val inputComponentId = globalStreamId.get_componentId
+        if (inputComponentId.equals(componentId)) {
+          val curr = allTargets.getOrElse(inputStreamId, Map.empty[String, Grouping])
+          allTargets + (inputStreamId -> (curr + (otherComponentId -> grouping)))
+        } else {
+          allTargets
+        }
+    }
+  }
+
+  def groupingToPartitioner(outFields: Fields, grouping: Grouping): Partitioner = {
+    grouping.getSetField match {
+      case Grouping._Fields.FIELDS =>
+        if (isGlobalGrouping(grouping)) new GlobalGroupingPartitioner
+        else new FieldsGroupingPartitioner(outFields, new Fields(grouping.get_fields()))
+      case Grouping._Fields.SHUFFLE =>
+        new ShuffleGroupingPartitioner
+      case Grouping._Fields.ALL =>
+        throw new RuntimeException("all grouping not supported")
+      case Grouping._Fields.NONE =>
+        new NoneGroupingPartitioner
+      case Grouping._Fields.CUSTOM_SERIALIZED =>
+        throw new RuntimeException("custom serialized grouping not supported")
+      case Grouping._Fields.CUSTOM_OBJECT =>
+        throw new RuntimeException("custom object grouping not supported")
+      case Grouping._Fields.DIRECT =>
+        throw new RuntimeException("direct grouping not supported")
+      case Grouping._Fields.LOCAL_OR_SHUFFLE =>
+        // GearPump has built-in support for sending messages to local actor
+        new ShuffleGroupingPartitioner
+    }
+  }
+
+  def isGlobalGrouping(grouping: Grouping): Boolean = {
+    grouping.getSetField == Grouping._Fields.FIELDS &&
+    grouping.get_fields.isEmpty
+  }
+}

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/util/StormTuple.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/util/StormTuple.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.util
+
+private[storm] case class StormTuple(values: List[AnyRef], sourceTaskId: Int, streamId: String)

--- a/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/util/StormUtil.scala
+++ b/experiments/storm/src/main/scala/org/apache/gearpump/experiments/storm/util/StormUtil.scala
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.util
+
+import java.io.{File, FileOutputStream, IOException}
+import java.util.jar.JarFile
+import java.util.{HashMap => JHashMap, List => JList, Map => JMap}
+
+import akka.actor.ActorSystem
+import backtype.storm.generated.{ComponentCommon, StormTopology}
+import backtype.storm.task.TopologyContext
+import backtype.storm.tuple.Fields
+import backtype.storm.utils.Utils
+import clojure.lang.Atom
+import org.apache.commons.io.{FileUtils, IOUtils}
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming._
+import org.apache.gearpump.util.LogUtil
+import org.json.simple.JSONValue
+
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+object StormUtil {
+  val TOPOLOGY = "topology"
+  val PROCESSOR_TO_COMPONENT = "processor_to_component"
+  val STORM_CONFIG = "storm_config"
+  val STORM_CONTEXT = "storm_context"
+
+  private val LOG = LogUtil.getLogger(StormUtil.getClass)
+
+  private val stormConfig = Utils.readStormConfig().asInstanceOf[JMap[AnyRef, AnyRef]]
+
+  def getTopology(config: UserConfig)(implicit system: ActorSystem) : StormTopology = {
+    config.getValue[StormTopology](TOPOLOGY)
+      .getOrElse(throw new RuntimeException("storm topology is not found"))
+  }
+
+  def getProcessorToComponent(config: UserConfig)(implicit system: ActorSystem) : Map[Int, String] = {
+    config.getValue[List[(ProcessorId, String)]](PROCESSOR_TO_COMPONENT)
+      .getOrElse(throw new RuntimeException("processor to component map is not found"))
+      .toMap
+  }
+
+  def getStormConfig(config: UserConfig)(implicit system: ActorSystem) : JMap[_, _] = {
+    val serConf = config.getValue[String](STORM_CONFIG)
+      .getOrElse(throw new RuntimeException("storm config not found"))
+    val conf = JSONValue.parse(serConf).asInstanceOf[JMap[AnyRef, AnyRef]]
+    stormConfig.putAll(conf)
+    stormConfig
+  }
+
+  def getTopologyContext(topology: StormTopology,
+                         stormConf: JMap[_, _],
+                         processorToComponent: Map[Int, String],
+                         taskId: Int): TopologyContext = {
+    val taskToComponent = getTaskToComponent(processorToComponent)
+    val componentToSortedTasks = getComponentToSortedTasks(processorToComponent)
+    val componentToStreamFields = getComponentToStreamFields(topology)
+    val codeDir = mkCodeDir
+    val pidDir = mkPidDir
+    new TopologyContext(
+      topology, stormConf, taskToComponent,
+      componentToSortedTasks, componentToStreamFields, null,
+      codeDir, pidDir, taskId, null, null, null, null, null, new JHashMap[AnyRef, AnyRef], new Atom(false))
+  }
+
+  // a workaround to support storm ShellBolt
+  def mkPidDir: String = {
+    val pidDir = FileUtils.getTempDirectoryPath + File.separator + "pid"
+    try {
+      FileUtils.forceMkdir(new File(pidDir))
+    } catch {
+      case ex: IOException =>
+        LOG.error(s"failed to create pid directory $pidDir")
+    }
+    pidDir
+  }
+
+  // a workaround to support storm ShellBolt
+  def mkCodeDir: String = {
+    val jarPath = System.getProperty("java.class.path").split(":").last
+    val destDir = FileUtils.getTempDirectoryPath + File.separator + "storm"
+
+    try {
+      FileUtils.forceMkdir(new File(destDir))
+
+      val jar = new JarFile(jarPath)
+      val enumEntries = jar.entries()
+      enumEntries.foreach { entry =>
+        val file = new File(destDir + File.separator + entry.getName)
+        if (!entry.isDirectory) {
+          file.getParentFile.mkdirs()
+
+          val is = jar.getInputStream(entry)
+          val fos = new FileOutputStream(file)
+          try {
+            IOUtils.copy(is, fos)
+          } catch {
+            case ex: IOException =>
+              LOG.error(s"failed to copy data from ${entry.getName} to ${file.getName}")
+          } finally {
+            fos.close()
+            is.close()
+          }
+        }
+      }
+    } catch {
+      case ex: IOException =>
+        LOG.error(s"could not extract $destDir from $jarPath")
+    }
+
+    destDir + File.separator + "resources"
+  }
+
+  def getTaskToComponent(processorToComponent: Map[Int, String]): JMap[Integer, String] = {
+    processorToComponent.map { case (pid, cid) =>
+      (pid.asInstanceOf[Integer], cid)
+    }.asJava
+  }
+
+  def getComponentToSortedTasks(processorToComponent: Map[Int, String]): JMap[String, JList[Integer]] = {
+    processorToComponent.map { case (pid, cid) =>
+      (cid, List(pid.asInstanceOf[Integer]).asJava)
+    }.asJava
+  }
+
+  def getComponentToStreamFields(topology: StormTopology) = {
+    val spouts = topology.get_spouts()
+    val bolts = topology.get_bolts()
+
+    def getComponentToFields(common: ComponentCommon) = {
+         common.get_streams.map { case (sid, stream) =>
+          sid -> new Fields(stream.get_output_fields())
+        }.toMap
+    }
+    (spouts.map{ case (id, component) =>
+      id -> getComponentToFields(component.get_common()).asJava
+    } ++
+      bolts.map { case (id, component) =>
+        id -> getComponentToFields(component.get_common()).asJava
+      }).toMap.asJava
+  }
+}

--- a/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/GraphBuilderSpec.scala
+++ b/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/GraphBuilderSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm
+
+import backtype.storm.generated.ComponentObject
+import backtype.storm.utils.Utils
+import org.apache.gearpump.experiments.storm.util.{GraphBuilder, TopologyUtil}
+import org.scalatest.{Matchers, WordSpec}
+
+class GraphBuilderSpec extends WordSpec with Matchers {
+
+  "GraphBuilder" should {
+    val topology = TopologyUtil.getTestTopology
+    val spouts = topology.get_spouts()
+    val bolts = topology.get_bolts()
+
+    "build Graph from Storm topology" in {
+      val graphBuilder = new GraphBuilder(topology)
+      graphBuilder.build()
+      val processorGraph = graphBuilder.getProcessorGraph
+      val processorToComponent = graphBuilder.getProcessorToComponent
+      processorGraph.vertices.size shouldBe 4
+      processorGraph.edges.length shouldBe 3
+      processorToComponent.size shouldBe 4
+      processorToComponent foreach { case (processor, component) =>
+        if (spouts.containsKey(component)) {
+          spouts.get(component).get_spout_object().getSetField shouldBe ComponentObject._Fields.SERIALIZED_JAVA
+        } else if (bolts.containsKey(component)) {
+          bolts.get(component).get_bolt_object().getSetField shouldBe ComponentObject._Fields.SERIALIZED_JAVA
+        }
+      }
+    }
+
+    "get target components for a source of topology" in {
+      val graphBuilder = new GraphBuilder(topology)
+      val targets = graphBuilder.getTargets("2")
+      targets.contains(Utils.DEFAULT_STREAM_ID)  shouldBe true
+      targets.get(Utils.DEFAULT_STREAM_ID).get.contains("3") shouldBe true
+      targets.get(Utils.DEFAULT_STREAM_ID).get("3").is_set_fields shouldBe true
+    }
+  }
+
+}

--- a/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/partitioner/FieldsGroupingPartitionerSpec.scala
+++ b/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/partitioner/FieldsGroupingPartitionerSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.partitioner
+
+import backtype.storm.tuple.Fields
+import backtype.storm.utils.Utils
+import org.apache.gearpump.Message
+import org.apache.gearpump.experiments.storm.util.StormTuple
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{Matchers, PropSpec}
+
+import scala.collection.JavaConversions._
+import scala.collection.convert._
+
+class FieldsGroupingPartitionerSpec extends PropSpec with PropertyChecks with Matchers {
+
+  property("FieldsGroupingPartitioner should get partition based on grouping fields' hashcode") {
+    val outFieldsGen = Gen.listOf[String](Gen.alphaStr).map(_.toSet.toList) suchThat (_.size > 0)
+    val partitionNumGen = Gen.chooseNum[Int](1, 1000)
+    val sourceTaskIdGen = Gen.chooseNum[Int](0, 1000)
+
+    forAll(outFieldsGen, partitionNumGen, sourceTaskIdGen) { (outFields: List[String], partitionNum: Int, sourceTaskId: Int) =>
+      1.to(outFields.length).foreach { num =>
+        val groupingFields = outFields.take(num)
+        val partitioner = new FieldsGroupingPartitioner(new Fields(outFields), new Fields(groupingFields))
+        val hash = WrapAsJava.seqAsJavaList[String](groupingFields).hashCode
+        val expectedPartitionNum = hash % partitionNum
+        partitioner.getPartition(Message(StormTuple(outFields, sourceTaskId, Utils.DEFAULT_STREAM_ID)), partitionNum) shouldBe expectedPartitionNum
+      }
+
+    }
+  }
+}

--- a/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/partitioner/GlobalGroupingPartitionerSpec.scala
+++ b/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/partitioner/GlobalGroupingPartitionerSpec.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.partitioner
+
+import org.apache.gearpump.Message
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{Matchers, PropSpec}
+
+class GlobalGroupingPartitionerSpec extends PropSpec with PropertyChecks with Matchers {
+
+  property("GlobalGroupingPartitioner should always get partition 0") {
+    val messageGen = Gen.alphaStr.map(Message(_))
+    val partitionNumGen = Gen.chooseNum[Int](1, 1000)
+    forAll(messageGen, partitionNumGen) { (message: Message, partitionNum: Int) =>
+      val partitioner = new GlobalGroupingPartitioner
+      partitioner.getPartition(message, partitionNum) shouldBe 0
+    }
+  }
+}

--- a/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/processor/StormBoltOutputCollectorSpec.scala
+++ b/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/processor/StormBoltOutputCollectorSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.processor
+
+import backtype.storm.utils.Utils
+import org.apache.gearpump.Message
+import org.apache.gearpump.experiments.storm.util.StormTuple
+import org.apache.gearpump.streaming.MockUtil
+import org.mockito.Mockito._
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{Matchers, PropSpec}
+
+import scala.collection.JavaConversions._
+
+class StormBoltOutputCollectorSpec extends PropSpec with PropertyChecks with Matchers {
+
+  property("StormBoltOutputCollector should output messages as list") {
+    val valGen = Gen.oneOf(Gen.alphaStr, Gen.alphaChar, Gen.chooseNum[Int](0, 1000))
+    val valuesGen = Gen.listOf[AnyRef](valGen)
+    val pidGen = Gen.chooseNum[Int](0, 1000)
+    forAll(valuesGen, pidGen) { (values: List[AnyRef], pid: Int) =>
+      val taskContext = MockUtil.mockTaskContext
+
+      val collector = new StormBoltOutputCollector(pid, taskContext)
+      collector.emit(Utils.DEFAULT_STREAM_ID, null, values)
+      verify(taskContext).output(MockUtil.argMatch[Message] { msg =>
+        msg.msg.asInstanceOf[StormTuple] == StormTuple(values, pid, Utils.DEFAULT_STREAM_ID)
+      })
+    }
+  }
+}

--- a/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/processor/StormProcessorSpec.scala
+++ b/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/processor/StormProcessorSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.processor
+
+import akka.actor.ActorSystem
+import backtype.storm.utils.Utils
+import org.apache.gearpump.Message
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.experiments.storm.util.{StormTuple, GraphBuilder, TopologyUtil}
+import org.apache.gearpump.streaming.MockUtil
+import org.apache.gearpump.streaming.task.{StartTime, TaskId}
+import org.json.simple.JSONValue
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{Matchers, PropSpec}
+import scala.collection.JavaConversions._
+
+class StormProcessorSpec extends PropSpec with PropertyChecks with Matchers {
+  import org.apache.gearpump.experiments.storm.util.StormUtil._
+
+  property("StormProcessor should work") {
+    implicit val system = ActorSystem("test")
+    val topology = TopologyUtil.getTestTopology
+    val graphBuilder = new GraphBuilder(topology)
+    graphBuilder.build()
+    val processorToComponent = graphBuilder.getProcessorToComponent
+    val componentToProcessor = graphBuilder.getComponenToProcessor
+    val stormConfig = Utils.readStormConfig()
+    val userConfig = UserConfig.empty
+      .withValue(TOPOLOGY, topology)
+      .withValue(PROCESSOR_TO_COMPONENT, processorToComponent.toList)
+      .withValue(STORM_CONFIG, JSONValue.toJSONString(stormConfig))
+    val fieldGen = Gen.alphaStr
+    forAll(fieldGen) { (field: String) =>
+      val values: List[AnyRef] = List(field)
+      topology.get_bolts foreach { case (id, bolt) =>
+        bolt.get_common().get_inputs() foreach { case(streamId, _) =>
+          componentToProcessor.get(streamId.get_componentId()) foreach { sourceTaskId =>
+            componentToProcessor.get(id).foreach { pid =>
+              val taskContext = MockUtil.mockTaskContext
+              when(taskContext.taskId).thenReturn(TaskId(pid, 0))
+              val stormProcessor = new StormProcessor(taskContext, userConfig)
+              stormProcessor.onStart(StartTime(0))
+              stormProcessor.onNext(Message(StormTuple(values, sourceTaskId, Utils.DEFAULT_STREAM_ID)))
+              verify(taskContext).output(anyObject())
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/producer/StormProducerSpec.scala
+++ b/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/producer/StormProducerSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.producer
+
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+import backtype.storm.utils.Utils
+import org.apache.gearpump.Message
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.experiments.storm.util.{GraphBuilder, TopologyUtil}
+import org.apache.gearpump.streaming.MockUtil
+import org.apache.gearpump.streaming.task.{StartTime, TaskId}
+import org.json.simple.JSONValue
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{Matchers, PropSpec}
+import scala.collection.JavaConversions._
+
+class StormProducerSpec extends PropSpec with PropertyChecks with Matchers {
+  import org.apache.gearpump.experiments.storm.util.StormUtil._
+
+  property("StormProducer should work") {
+    implicit val system = ActorSystem("test")
+    val topology = TopologyUtil.getTestTopology
+    val graphBuilder = new GraphBuilder(topology)
+    graphBuilder.build()
+    val processorToComponent = graphBuilder.getProcessorToComponent
+    val stormConfig = Utils.readStormConfig()
+    val userConfig = UserConfig.empty
+      .withValue(TOPOLOGY, topology)
+      .withValue(PROCESSOR_TO_COMPONENT, processorToComponent.toList)
+      .withValue(STORM_CONFIG, JSONValue.toJSONString(stormConfig))
+
+    val mockTaskActor = TestProbe()
+
+    topology.get_spouts foreach { case (id, _) =>
+      processorToComponent.find(_._2 == id).foreach { case (pid, _) =>
+        val taskContext = MockUtil.mockTaskContext
+        when(taskContext.self).thenReturn(mockTaskActor.ref)
+        when(taskContext.taskId).thenReturn(TaskId(pid, 0))
+        val stormProducer = new StormProducer(taskContext, userConfig)
+        stormProducer.onStart(StartTime(0))
+        mockTaskActor.expectMsgType[Message]
+        stormProducer.onNext(Message("Next"))
+        mockTaskActor.expectMsgType[Message]
+        verify(taskContext).output(anyObject())
+      }
+    }
+  }
+}

--- a/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/producer/StormSpoutOutputCollectorSpec.scala
+++ b/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/producer/StormSpoutOutputCollectorSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.producer
+
+import backtype.storm.utils.Utils
+import org.apache.gearpump.Message
+import org.apache.gearpump.experiments.storm.util.StormTuple
+import org.apache.gearpump.streaming.MockUtil
+import org.mockito.Mockito._
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{Matchers, PropSpec}
+
+import scala.collection.JavaConversions._
+
+class StormSpoutOutputCollectorSpec extends PropSpec with PropertyChecks with Matchers {
+
+  property("StormSpoutOutputCollector should output messages as list") {
+    val valGen = Gen.oneOf(Gen.alphaStr, Gen.alphaChar, Gen.chooseNum[Int](0, 1000))
+    val valuesGen = Gen.listOf[AnyRef](valGen)
+    val pidGen = Gen.chooseNum[Int](0, 1000)
+    forAll(valuesGen, pidGen) { (values: List[AnyRef], pid: Int) =>
+      val taskContext = MockUtil.mockTaskContext
+
+      val collector = new StormSpoutOutputCollector(pid, taskContext)
+      collector.emit(Utils.DEFAULT_STREAM_ID, values, null)
+      verify(taskContext).output(MockUtil.argMatch[Message] { msg =>
+        msg.msg.asInstanceOf[StormTuple] == StormTuple(values, pid, Utils.DEFAULT_STREAM_ID)
+      })
+    }
+  }
+
+}

--- a/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/util/StormUtilSpec.scala
+++ b/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/util/StormUtilSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.util
+
+import akka.actor.ActorSystem
+import backtype.storm.generated.StormTopology
+import org.apache.gearpump.cluster.UserConfig
+import org.scalatest.{Matchers, PropSpec}
+
+class StormUtilSpec extends PropSpec with Matchers {
+
+  implicit val system = ActorSystem("test")
+
+  property("get storm topology through user config") {
+    val topology = TopologyUtil.getTestTopology
+    val config = UserConfig.empty.withValue[StormTopology](StormUtil.TOPOLOGY, topology)
+    StormUtil.getTopology(config) shouldBe topology
+  }
+
+  property("get processor to component mapping through user config") {
+    val topology = TopologyUtil.getTestTopology
+    val graphBuilder = GraphBuilder(topology)
+    graphBuilder.build()
+    val processorToComponent = graphBuilder.getProcessorToComponent
+    val config = UserConfig.empty.withValue[List[(Int, String)]](
+      StormUtil.PROCESSOR_TO_COMPONENT, processorToComponent.toList)
+    StormUtil.getProcessorToComponent(config) shouldBe processorToComponent
+  }
+}

--- a/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/util/TopologyUtil.scala
+++ b/experiments/storm/src/test/scala/org/apache/gearpump/experiments/storm/util/TopologyUtil.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.experiments.storm.util
+
+import backtype.storm.generated.StormTopology
+import backtype.storm.testing.{TestGlobalCount, TestWordCounter, TestWordSpout}
+import backtype.storm.topology.TopologyBuilder
+import backtype.storm.tuple.Fields
+
+object TopologyUtil {
+
+  def getTestTopology: StormTopology = {
+    val topologyBuilder = new TopologyBuilder
+    topologyBuilder.setSpout("1", new TestWordSpout(true), 5)
+    topologyBuilder.setSpout("2", new TestWordSpout(true), 3)
+    topologyBuilder.setBolt("3", new TestWordCounter(), 3)
+      .fieldsGrouping("1", new Fields("word"))
+      .fieldsGrouping("2", new Fields("word"))
+    topologyBuilder.setBolt("4", new TestGlobalCount()).globalGrouping("1")
+    topologyBuilder.createTopology()
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -36,6 +36,7 @@ object Build extends sbt.Build {
   val jgraphtVersion = "0.9.0"
   val json4sVersion = "3.2.10"
   val kafkaVersion = "0.8.2.1"
+  val stormVersion = "0.9.3"
   val sigarVersion = "1.6.4"
   val slf4jVersion = "1.7.7"
   
@@ -90,7 +91,7 @@ object Build extends sbt.Build {
       },
 
       publishArtifact in Test := true,
-      
+
       pomExtra := {
       <url>https://github.com/intel-hadoop/gearpump</url>
       <licenses>
@@ -191,7 +192,8 @@ object Build extends sbt.Build {
         packExtraClasspath := new DefaultValueMap(Seq("${PROG_HOME}/conf", "${PROG_HOME}/dashboard"))
       )
   ).dependsOn(core, streaming, services, external_kafka)
-   .aggregate(core, streaming, fsio, examples_kafka, sol, wordcount, complexdag, services, external_kafka, examples, distributedshell, distributeservice)
+   .aggregate(core, streaming, fsio, examples_kafka, sol, wordcount, complexdag, services, external_kafka, examples, distributedshell, distributeservice, storm)
+
 
   lazy val core = Project(
     id = "gearpump-core",
@@ -328,5 +330,32 @@ object Build extends sbt.Build {
     base = file("experiments/distributeservice"),
     settings = commonSettings
   ) dependsOn(core % "test->test;compile->compile")
+
+  lazy val storm = Project(
+    id = "gearpump-experiments-storm",
+    base = file("experiments/storm"),
+    settings = commonSettings ++
+      Seq(
+        libraryDependencies ++= Seq(
+          "org.apache.storm" % "storm-core" % stormVersion
+            exclude("clj-stacktrace", "clj-stacktrace")
+            exclude("clj-time", "clj-time")
+            exclude("clout", "clout")
+            exclude("compojure", "compojure")
+            exclude("com.esotericsoftware.kryo", "kryo")
+            exclude("com.twitter", "carbonite")
+            exclude("hiccup", "hiccup")
+            exclude("javax.servlet", "servlet-api")
+            exclude("ring", "ring-core")
+            exclude("ring", "ring-devel")
+            exclude("ring", "ring-jetty-adapter")
+            exclude("ring", "ring-servlet"),
+          "org.apache.storm" % "storm-starter" % stormVersion,
+          "org.scalatest" %% "scalatest" % scalaTestVersion % "test",
+          "org.scalacheck" %% "scalacheck" % scalaCheckVersion % "test",
+          "org.mockito" % "mockito-core" % mockitoVersion % "test"
+        )
+      )
+  ) dependsOn (streaming % "test->test; provided")
 
 }


### PR DESCRIPTION
This pr is to give binary support for storm applications over gearpump.  As a new feature / module, I put it in experiments. Basic topologies should work now. I also verified simple kafka and hbase examples. 

Users need to cofigure 

```
  serializers {
#      ## Follow this format when adding new serializer for new message types
#      ##    "org.apache.gearpump.Message" = "org.apache.gearpump.streaming.MessageSerializer"
    "org.apache.gearpump.experiments.storm.util.StormTuple" = ""
  }
```

in `gear.conf` and then submit a storm topology as gearpump application
```bash
 ./target/pack/bin/gear app -jar examples/target/scala-2.11/gearpump-examples-assembly-0.3.2-SNAPSHOT.jar org.apache.gearpump.experiments.storm.StormRunner -storm_topology storm.starter.WordCountTopology -storm_args wordcount -master 127.0.0.1:3000
```
The storm topology should be already included as dependency. 

The idea is to launch a thrift server whose life cycle is bound to the client process. The thrift server is like a storm nimbus although with much much fewer functions. It will translate storm topology to gearpump dag and submit the dag to gearpump master.

I'll write up a more detailed document later.  

   

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/630)
<!-- Reviewable:end -->
