### PR TITLE
fix #654, Use yarn to distribute whole gearpump package instead of jars under lib/. load log4j.properties into classpath so that we have logs.

### DIFF
--- a/experiments/yarn/src/main/scala/org/apache/gearpump/experiments/yarn/master/ContainerLauncherActor.scala
+++ b/experiments/yarn/src/main/scala/org/apache/gearpump/experiments/yarn/master/ContainerLauncherActor.scala
@@ -8,11 +8,11 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration
 import org.apache.hadoop.yarn.conf.YarnConfiguration
 import akka.actor._
 
-class ContainerLauncherActor(container: Container, nodeManagerClient: NMClientAsync,  yarnConf: YarnConfiguration, command: String) extends Actor {
+class ContainerLauncherActor(container: Container, nodeManagerClient: NMClientAsync,  yarnConf: YarnConfiguration, command: String, version: String) extends Actor {
   val LOG = LogUtil.getLogger(getClass)  
   
   override def preStart(): Unit = {
-    nodeManagerClient.startContainerAsync(container, YarnContainerUtil.getContainerContext(yarnConf, command))
+    nodeManagerClient.startContainerAsync(container, YarnContainerUtil.getContainerContext(yarnConf, version, command))
   }
 
   override def receive: Receive = {


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/655)
<!-- Reviewable:end -->
