### PR TITLE
fix #672, extend Task to support unmanaged messages so that every task can serve as full functional service

### DIFF
--- a/streaming/src/main/scala/org/apache/gearpump/streaming/task/Task.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/task/Task.scala
@@ -18,6 +18,7 @@
 
 package org.apache.gearpump.streaming.task
 
+import akka.actor.Actor.Receive
 import akka.actor.{Cancellable, Props, ActorRef, ActorSystem}
 import org.apache.gearpump.Message
 import org.apache.gearpump.cluster.UserConfig
@@ -130,6 +131,15 @@ trait TaskContext {
    * @return
    */
   def scheduleOnce(initialDelay: FiniteDuration)(f: ⇒ Unit): Cancellable
+
+   /**
+   * For managed message(type of Message), the sender only serve as a unique Id,
+   * It's address is not something meaningful, you should not use this directly
+   *
+   * For unmanaged message, the sender represent the sender ActorRef
+   * @return
+   */
+   def sender: ActorRef
 }
 
 /**
@@ -151,6 +161,12 @@ trait TaskInterface {
    * This can be used to cleanup resource when the application finished.
    */
   def onStop() : Unit
+
+  /**
+   * handler for unmanaged message
+  * @return
+  */
+  def receiveUnManagedMessage: Receive = null
 }
 
 abstract class Task(taskContext : TaskContext, userConf : UserConfig) extends TaskInterface{
@@ -163,9 +179,23 @@ abstract class Task(taskContext : TaskContext, userConf : UserConfig) extends Ta
 
   implicit val self = taskContext.self
 
+  /**
+     * For managed message(type of Message), the sender mean nothing,
+   * you should not use this directory
+   *
+   * For unmanaged message, the sender represent the sender actor
+   * @return
+   */
+    protected def sender: ActorRef = taskContext.sender
+
   def onStart(startTime : StartTime) : Unit
 
   def onNext(msg : Message) : Unit
 
   def onStop() : Unit = {}
+
+  override def receiveUnManagedMessage: Receive = {
+    case msg =>
+      LOG.error("Failed! Received unknown message " + "taskId: " + taskId + ", " + msg.toString)
+  }
 }

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskActor.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskActor.scala
@@ -81,6 +81,8 @@ class TaskActor(val taskContextData : TaskContextData, userConf : UserConfig, va
 
   def onNext(msg : Message) : Unit = task.onNext(msg)
 
+  def onUnManagedMessage(msg: Any): Unit = task.receiveUnManagedMessage.apply(msg)
+
   def onStop() : Unit = task.onStop()
 
   def output(msg : Message) : Unit = {
@@ -292,7 +294,8 @@ class TaskActor(val taskContextData : TaskContextData, userConf : UserConfig, va
     case LatencyProbe(timeStamp) =>
       receiveLatency.update(System.currentTimeMillis() - timeStamp)
     case other =>
-      LOG.error("Failed! Received unknown message " + "taskId: " + taskId + ", " + other.toString)
+      // un-managed message
+      onUnManagedMessage(other)
   }
 }
 

--- a/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskWrapper.scala
+++ b/streaming/src/main/scala/org/apache/gearpump/streaming/task/TaskWrapper.scala
@@ -58,7 +58,9 @@ class TaskWrapper(taskClass: Class[_ <: Task], context: TaskContextData, userCon
 
   override def output(msg: Message): Unit = actor.output(msg)
 
-  def self: ActorRef = actor.context.self
+  override def self: ActorRef = actor.context.self
+
+  override def sender: ActorRef = actor.context.sender()
 
   def system: ActorSystem = actor.context.system
 


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/674)
<!-- Reviewable:end -->
