### PR TITLE
Issue #684 - setting -Xmx for master and worker when running on Yarn. 

### DIFF
--- a/conf/yarn.conf.template
+++ b/conf/yarn.conf.template
@@ -18,7 +18,7 @@ gearpump {
   }
   
   master {
-    command = "$JAVA_HOME/bin/java"
+    command = "$JAVA_HOME/bin/java -Xmx256m"
     main = "org.apache.gearpump.cluster.main.Master"
     containers = "1"
     ip = ""
@@ -29,7 +29,7 @@ gearpump {
   }
   
   worker {
-    command = "$JAVA_HOME/bin/java"
+    command = "$JAVA_HOME/bin/java -Xmx256m"
     main = "org.apache.gearpump.cluster.main.Worker"    
     containers = "1"
     memory = "1024"


### PR DESCRIPTION
Setting -Xmx256m. For now it seems like more than enough. I've also checked that with this setting JVMs won't exceed container limit and won't be killed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/808)
<!-- Reviewable:end -->
