### PR TITLE
fix #6, add transaction api

### DIFF
--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/api/State.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/api/State.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.api
+
+import com.twitter.algebird.Monoid
+import com.twitter.bijection.Injection
+
+/**
+ * basic interface of State API
+ * it defines how a state gets
+ *   1. initialized
+ *   2. updated on new data
+ *   3. serialized
+ *   4. deserialized
+ * users should extend MonoidState
+ */
+sealed trait State[S, D] {
+  /**
+   * use Twitter Bijection / Injection for serialization
+   * and deserialization. For data types provided
+   * by Bijection / Injection, users only need to import them;
+   * otherwise, users are required to define their
+   * own Bijection / Injection
+   * @return
+   */
+  def injection: Injection[S, Array[Byte]]
+
+  def init: S
+
+  /**
+   * update existing state S on new data D
+   */
+  def update(state: S, data: D): S
+
+  def serialize(state: S): Array[Byte] = {
+    injection(state)
+  }
+
+  def deserialize(bytes: Array[Byte]): S = {
+    injection.invert(bytes).getOrElse(
+      throw new RuntimeException("deserialize failed"))
+  }
+}
+
+/**
+ * state that incorporates Twitter Algebird monoid
+ * this requires state and data to be of the same type
+ *
+ * here is an example of how to easily define a state using
+ * algebird and bijection
+ * e.g.
+ *
+ * import com.twitter.algebird.Monoid
+ * import com.twitter.algebird.Monoid._
+ * import com.twitter.bijection.Bijection
+ * import com.twitter.bijection.Bijection._
+ *
+ * class IntState extends MonoidState[Int] {
+ *   override def monoid = intMonoid
+ *   override def injection = int2BigEndian
+ * }
+ */
+trait MonoidState[T] extends State[T, T] {
+  /**
+   * for monoids provided by Algebird, users get them
+   * for free through import; otherwise, users would need
+   * to define their own monoid.
+   */
+  def monoid: Monoid[T]
+
+  override def init: T = monoid.zero
+
+  override def update(state: T, data: T): T = {
+    monoid.plus(state, data)
+  }
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/api/StatefulTask.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/api/StatefulTask.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.api
+
+import org.apache.gearpump._
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.state.internal.api.{CheckpointStoreFactory, WindowManager}
+import org.apache.gearpump.streaming.state.internal.impl.{WindowStateManager, DefaultStateManager, DefaultCheckpointManager}
+import org.apache.gearpump.streaming.state.util.StateConfig
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
+
+/**
+ * StatefulTask provides transaction and state support for users
+ * users should extend this class if their application requires state management and exact-once processing
+ * they only need to override the onUpdate method which defines how to get raw data of type T from message
+ */
+abstract class StatefulTask[T](state: MonoidState[T], taskContext : TaskContext, conf: UserConfig)
+  extends Task(taskContext, conf) {
+
+  private val stateConfig = new StateConfig(conf)
+  private val window = stateConfig.getWindow
+  private val checkpointInterval = stateConfig.getCheckpointInterval
+  private val checkpointStore = stateConfig.getCheckpointStoreFactory
+    .getCheckpointStore(conf, taskContext)
+  private val checkpointManager = new DefaultCheckpointManager(checkpointStore,  checkpointInterval)
+  private val stateManager = window match {
+    case Some(Window(duration, period)) =>
+      val windowSize = checkpointInterval
+      val windowNum = duration.toMillis / windowSize
+      val windowStride = period.toMillis / windowSize
+      val windowManager = new WindowManager(windowSize, windowNum, windowStride)
+      new WindowStateManager[T](state, checkpointInterval, checkpointManager, windowManager, taskContext)
+    case None =>
+      new DefaultStateManager[T](state, checkpointInterval, checkpointManager, taskContext)
+  }
+
+
+  def onUpdate(msg: Message): T
+
+  override def onStart(startTime: StartTime): Unit = {
+    stateManager.init(startTime.startTime)
+  }
+
+  override def onNext(msg: Message): Unit = {
+    stateManager.update(msg, onUpdate, taskContext.upstreamMinClock)
+  }
+
+  override def stateClock: Option[TimeStamp] = {
+    Option(stateManager.minClock)
+  }
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/api/Window.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/api/Window.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.api
+
+import scala.concurrent.duration.Duration
+
+
+object Window {
+  def apply(duration: Duration): Window = Window(duration, duration)
+}
+
+/**
+ * interface to define window functions
+ *
+ * a Window will cover a time duration and move forward for each period
+ * e.g. time ranges for a Window(5 seconds, 1 seconds) would be like
+ * [0, 5), [1, 6), [2, 7), ...
+ *
+ * @param duration length of time covered by a window
+ * @param period interval of window moving forward
+ */
+case class Window(duration: Duration, period: Duration)
+

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/MessageCount.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/MessageCount.scala
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example
+
+import com.typesafe.config.ConfigFactory
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.cluster.client.ClientContext
+import org.apache.gearpump.cluster.main.{ParseResult, CLIOption, ArgumentsParser}
+import org.apache.gearpump.partitioner.HashPartitioner
+import org.apache.gearpump.streaming.kafka.lib.KafkaConfig
+import org.apache.gearpump.streaming.state.example.processor.{CountProcessor, GenNumProcessor}
+import org.apache.gearpump.streaming.state.internal.impl.HadoopCheckpointStoreFactory
+import org.apache.gearpump.streaming.state.util.StateConfig
+import org.apache.gearpump.streaming.{Processor, StreamApplication}
+import org.apache.gearpump.util.Graph
+import org.apache.gearpump.util.Graph.Node
+
+
+object MessageCount extends App with ArgumentsParser {
+
+  override val options: Array[(String, CLIOption[Any])] = Array(
+    "gen" -> CLIOption("<how many gen tasks>", required = false, defaultValue = Some(1)),
+    "count" -> CLIOption("<how mange count tasks", required = false, defaultValue = Some(1))
+  )
+
+  def application(config: ParseResult) : StreamApplication = {
+    val gen = Processor[GenNumProcessor](config.getInt("gen"))
+    val count = Processor[CountProcessor](config.getInt("count"))
+    val kafkaConfig = KafkaConfig(ConfigFactory.parseResources("kafka.conf"))
+    val userConfig = UserConfig.empty
+      .withLong(StateConfig.CHECKPOINT_INTERVAL_DEFAULT, 1000)
+      .withString(StateConfig.CHECKPOINT_STORE_FACTORY, classOf[HadoopCheckpointStoreFactory].getName)
+      .withString(StateConfig.HDFS_FS, "hdfs://localhost:9000")
+      .withValue(KafkaConfig.NAME, kafkaConfig)
+    val partitioner = new HashPartitioner()
+    val app = StreamApplication("MessageCount", Graph(gen ~ partitioner ~> count), userConfig)
+    app
+  }
+
+  val config = parse(args)
+  val context = ClientContext()
+  implicit val system = context.system
+  val appId = context.submit(application(config))
+  context.close()
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/WindowAverage.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/WindowAverage.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example
+
+import com.typesafe.config.ConfigFactory
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.cluster.client.ClientContext
+import org.apache.gearpump.cluster.main.{ArgumentsParser, CLIOption, ParseResult}
+import org.apache.gearpump.partitioner.HashPartitioner
+import org.apache.gearpump.streaming.kafka.lib.KafkaConfig
+import org.apache.gearpump.streaming.state.api.Window
+import org.apache.gearpump.streaming.state.example.processor.{WindowAverageProcessor, GenNumProcessor}
+import org.apache.gearpump.streaming.state.internal.impl.HadoopCheckpointStoreFactory
+import org.apache.gearpump.streaming.state.util.StateConfig
+import org.apache.gearpump.streaming.{Processor, StreamApplication}
+import org.apache.gearpump.util.Graph
+import org.apache.gearpump.util.Graph.Node
+
+import scala.concurrent.duration._
+
+object WindowAverage extends App with ArgumentsParser {
+
+  override val options: Array[(String, CLIOption[Any])] = Array(
+    "gen" -> CLIOption("<how many gen tasks>", required = false, defaultValue = Some(1)),
+    "count" -> CLIOption("<how mange count tasks", required = false, defaultValue = Some(1)),
+    "window" -> CLIOption("<window length in milliseconds>", required = false , defaultValue = Some(5000))
+  )
+
+  def application(config: ParseResult) : StreamApplication = {
+
+    val windowSize = Duration(config.getInt("window"), MILLISECONDS)
+    val kafkaConfig = KafkaConfig(ConfigFactory.parseResources("kafka.conf"))
+    val userConfig = UserConfig.empty
+      .withValue[Window](StateConfig.WINDOW, Window(windowSize))
+      .withLong(StateConfig.CHECKPOINT_INTERVAL_DEFAULT, 1000)
+      .withString(StateConfig.CHECKPOINT_STORE_FACTORY, classOf[HadoopCheckpointStoreFactory].getName)
+      .withString(StateConfig.HDFS_FS, "hdfs://localhost:9000")
+      .withValue(KafkaConfig.NAME, kafkaConfig)
+    val gen = Processor[GenNumProcessor](config.getInt("gen"))
+    val count = Processor[WindowAverageProcessor](config.getInt("count"))
+    val partitioner = new HashPartitioner()
+    val app = StreamApplication("WindowAverage", Graph(gen ~ partitioner ~> count), userConfig)
+    app
+  }
+
+  val config = parse(args)
+  val context = ClientContext()
+
+  implicit val system = context.system
+  val appId = context.submit(application(config))
+  context.close()
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/processor/CountProcessor.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/processor/CountProcessor.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example.processor
+
+import org.apache.gearpump.streaming.state.api.{MonoidState, StatefulTask}
+import org.apache.gearpump.Message
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.state.example.state.CountState
+import org.apache.gearpump.streaming.task.TaskContext
+
+class CountProcessor(taskContext: TaskContext, conf: UserConfig)
+  extends StatefulTask[Long](new CountState, taskContext, conf) {
+  override def onUpdate(message: Message): Long = 1L
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/processor/GenNumProcessor.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/processor/GenNumProcessor.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example.processor
+
+import org.apache.gearpump.Message
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.task.{StartTime, Task, TaskContext}
+
+class GenNumProcessor(taskContext : TaskContext, conf: UserConfig) extends Task(taskContext, conf) {
+  import taskContext.output
+
+  private var num = 0L
+  override def onStart(startTime: StartTime): Unit = {
+    num = startTime.startTime
+    self ! Message("start")
+  }
+
+  override def onNext(msg: Message): Unit = {
+    output(Message(num + "", num))
+    num += 1
+
+    import scala.concurrent.duration._
+    taskContext.scheduleOnce(Duration(1, MILLISECONDS))(self ! Message("next"))
+  }
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/processor/WindowAverageProcessor.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/processor/WindowAverageProcessor.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example.processor
+
+import com.twitter.algebird.AveragedValue
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.state.api.{MonoidState, StatefulTask}
+import org.apache.gearpump.streaming.state.example.state.WindowAverageState
+import org.apache.gearpump.streaming.task.TaskContext
+import org.apache.gearpump.util.LogUtil
+import org.apache.gearpump.Message
+import org.slf4j.Logger
+
+object WindowAverageProcessor {
+  val WINDOW_SIZE = "window_size"
+  val LOG: Logger = LogUtil.getLogger(classOf[WindowAverageProcessor])
+}
+
+class WindowAverageProcessor(taskContext : TaskContext, conf: UserConfig)
+  extends StatefulTask(new WindowAverageState, taskContext, conf) {
+
+  override def onUpdate(msg: Message): AveragedValue = {
+    AveragedValue(msg.msg.asInstanceOf[String].toLong)
+  }
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/state/CountState.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/state/CountState.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example.state
+
+import com.twitter.algebird.Monoid
+import com.twitter.algebird.Monoid._
+import com.twitter.bijection.Injection
+import com.twitter.bijection.Injection._
+import org.apache.gearpump.streaming.state.api.MonoidState
+
+class CountState extends MonoidState[Long] {
+  override def monoid: Monoid[Long] = longMonoid
+
+  override def injection: Injection[Long, Array[Byte]] = long2BigEndian
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/state/WindowAverageState.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/example/state/WindowAverageState.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example.state
+
+import com.twitter.algebird.{AveragedGroup, Monoid, AveragedValue}
+import com.twitter.bijection.{AbstractInjection, Injection}
+import org.apache.gearpump.streaming.state.api.MonoidState
+
+import scala.util.Try
+
+class WindowAverageState extends MonoidState[AveragedValue] {
+  val averagedValueInj = new AbstractInjection[AveragedValue, Array[Byte]] {
+    override def apply(a: AveragedValue): Array[Byte] = {
+      Injection[Long, Array[Byte]](a.count) ++ Injection[Double, Array[Byte]](a.value)
+    }
+
+    override def invert(b: Array[Byte]): Try[AveragedValue] = {
+      Injection.invert[Long, Array[Byte]](b.take(8)).flatMap(count =>
+        Injection.invert[Double, Array[Byte]](b.drop(8)).map(average =>
+          AveragedValue(count, average)))
+    }
+  }
+
+  override def monoid: Monoid[AveragedValue] = AveragedGroup
+
+  override def injection: Injection[AveragedValue, Array[Byte]] = averagedValueInj
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/api/CheckpointManager.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/api/CheckpointManager.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.api
+
+import org.apache.gearpump.TimeStamp
+
+/**
+ * CheckpointManager provides write/read user states to/from
+ * a persistent store (e.g. HDFS).
+ * It maintains
+ *   1. a checkpoint time which is advanced continuously by the configured
+ *   checkpoint interval on each checkpoint commit
+ */
+private[internal] trait CheckpointManager extends ClockListener {
+
+  /**
+   * store timestamp to data mapping
+   */
+  val checkpointStore: CheckpointStore
+
+  /**
+   * interval to write checkpoint to CheckpointStore
+   * @param interval in milliseconds
+   */
+  def setCheckpointInterval(interval: Long): Unit
+
+  /**
+   * @return checkpoint interval
+   */
+  def getCheckpointInterval: Long
+
+  /**
+   * read checkpoint at given timestamp from CheckpointStore
+   * @param timestamp
+   * @return
+   */
+  def recover(timestamp: TimeStamp): Option[Array[Byte]]
+
+  /**
+   * whether the timestamp has exceeded the checkpoint time
+   * @return
+   */
+  def shouldCheckpoint: Boolean
+
+  /**
+   * write out data at the timestamp to CheckpointStore
+   * @param timestamp
+   * @param data
+   */
+  def checkpoint(timestamp: TimeStamp, data: Array[Byte]): Unit
+
+  /**
+   * time to commit next checkpoint
+   * @return None if the internal clock is not synced yet
+   */
+  def getCheckpointTime: Option[TimeStamp]
+
+  /**
+   * close external resources like CheckpointStore
+   */
+  def close(): Unit
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/api/CheckpointStore.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/api/CheckpointStore.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.api
+
+import org.apache.gearpump.TimeStamp
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.task.TaskContext
+
+/**
+ * CheckpointStore persistently stores mapping of timestamp to checkpoint
+ * it's possible that two checkpoints have the same timestamp
+ * CheckpointStore needs to handle this either during write or read
+ */
+private[internal] trait CheckpointStore {
+  def write(timestamp: TimeStamp, checkpoint: Array[Byte]): Unit
+
+  def read(timestamp: TimeStamp): Option[Array[Byte]]
+
+  def close(): Unit
+}
+
+trait CheckpointStoreFactory {
+  def getCheckpointStore(conf: UserConfig, taskContext: TaskContext): CheckpointStore
+}
+

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/api/CheckpointWindow.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/api/CheckpointWindow.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.api
+
+import com.twitter.algebird.Semigroup
+import org.apache.gearpump.TimeStamp
+
+object CheckpointWindow {
+  implicit val windowSemigroup = new Semigroup[CheckpointWindow] {
+    override def plus(l: CheckpointWindow, r: CheckpointWindow): CheckpointWindow = {
+      if (r < l) {
+        plus(r, l)
+      } else if (l.endTime < r.startTime) {
+        throw new RuntimeException(s"cannot merge non-overlapping windows $l and $r")
+      } else {
+        CheckpointWindow(l.startTime, r.endTime)
+      }
+    }
+  }
+
+  def at(timestamp: TimeStamp, windowSize: Long): CheckpointWindow = {
+    val startClock = (timestamp / windowSize) * windowSize
+    val endClock = startClock + windowSize
+    CheckpointWindow(startClock, endClock)
+  }
+}
+/**
+ * time window between checkpoints, ranging
+ * from (including)startTime until (excluding)endTime
+ * @param startTime timestamp of data in the window is >= startTime
+ * @param endTime   timestamp of data in the window is < startTime
+ */
+private[internal] case class CheckpointWindow(startTime: TimeStamp, endTime: TimeStamp) extends Ordered[CheckpointWindow] {
+  override def compare(that: CheckpointWindow): Int = {
+      if (startTime < that.startTime) -1
+      else if (startTime > that.startTime) 1
+      else 0
+  }
+
+}
+

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/api/ClockListener.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/api/ClockListener.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.api
+
+import org.apache.gearpump.TimeStamp
+
+/**
+ * a ClockListener maintains a internal clock and sync time
+ * periodically with an external clock source
+ */
+trait ClockListener {
+  private var clock = 0L
+
+  def syncTime(timestamp: TimeStamp): Unit = {
+    this.clock = timestamp
+  }
+
+  def getTime: TimeStamp = clock
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/api/StateManager.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/api/StateManager.scala
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.api
+
+import org.apache.gearpump._
+import org.apache.gearpump.streaming.state.api.{MonoidState, State}
+import org.apache.gearpump.util.LogUtil
+import org.slf4j.Logger
+
+import scala.collection.immutable.TreeMap
+
+/**
+ * StateManager manages a state lifecycle for users
+ * which includes
+ *   1. init state at given time
+ *   2. update state on new message
+ *   3. checkpoint state in the background
+ *      if checkpoint time is exceeded (refer to CheckpointManager)
+ *
+ * It maintains
+ *   1. states divided by checkpoint window such that each message goes
+ *      to its own window and update the state there
+ *   2. state clock which advance on each checkpoint and will
+ * affect a task's minClock
+ *
+ * There are two StateManagers defined now
+ *   1. DefaultStateManager for general use
+ *   2. WindowStateManager for window functions
+ *
+ */
+private[internal] trait StateManager[T] {
+
+  val state: MonoidState[T]
+  val clockListeners: Array[ClockListener]
+  val checkpointWindowSize: Long
+  val checkpointManager: CheckpointManager
+
+  private var stateClock: TimeStamp = 0L
+  protected var states: TreeMap[CheckpointWindow, T] =
+    TreeMap.empty[CheckpointWindow, T]
+
+  private val LOG: Logger = LogUtil.getLogger(classOf[StateManager[T]])
+
+  /**
+   * init state at given time
+   * @param timestamp
+   */
+  def init(timestamp: TimeStamp): Unit = {
+    stateClock = timestamp
+  }
+  /**
+   * 1. update internal state on new message
+   * 2. checkpoint states exceeded by upstreamMinClock
+   * 3. advance state clock
+   */
+  def update(msg: Message, msgDecoder: Message => T, upstreamMinClock: TimeStamp): Unit = {
+    clockListeners.foreach(_.syncTime(upstreamMinClock))
+
+    val timestamp = msg.timestamp
+    val window = CheckpointWindow.at(timestamp, checkpointWindowSize)
+    val data = msgDecoder(msg)
+
+    updateState(window, timestamp, data)
+
+    if (checkpointManager.shouldCheckpoint) {
+      val checkpointTime = checkpointManager.getCheckpointTime.get
+      val statesToCheckpoint =
+        states
+          .dropWhile(_._1.endTime <= stateClock)
+          .takeWhile(_._1.endTime <= checkpointTime)
+      checkpoint(statesToCheckpoint)
+      stateClock = checkpointTime
+    }
+  }
+
+  def checkpoint(states: TreeMap[CheckpointWindow, T]): Unit
+
+  protected def dropStatesBefore(timestamp: TimeStamp): Unit = {
+    states = states.dropWhile(_._1.endTime <= timestamp)
+  }
+
+  /**
+   * report state clock to task
+   * @return state clock
+   */
+  def minClock: TimeStamp = stateClock
+
+  private[internal] def getStates: TreeMap[CheckpointWindow, T] = states
+
+  private def updateState(window: CheckpointWindow, timestamp: TimeStamp, data: T): Unit = {
+    states.get(window) match {
+      case Some(st) =>
+        states += window -> state.update(st, data)
+      case None =>
+        val maxClock = getMaxClock
+        if (maxClock.isEmpty || timestamp >= maxClock.get) {
+          states += window -> state.update(state.init, data)
+        } else {
+          LOG.warn(s"drop late message at $timestamp")
+        }
+    }
+  }
+
+  /**
+   * @return endTime of latest window
+   */
+  private def getMaxClock: Option[TimeStamp] = {
+    if (states.isEmpty) None
+    else Option(states.maxBy(_._1)._1.endTime)
+  }
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/api/WindowManager.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/api/WindowManager.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.api
+
+import org.apache.gearpump.TimeStamp
+
+/**
+ *
+ * a WindowManager manages windowNum of windows, and
+ * each of them has the length of windowSize. WindowManager
+ * move forward as time passes by its endTime
+ * In each forward, WindowManager will move ahead by windowStride
+ *
+ * @param windowSize defined by Window(duration, period) and checkpoint interval
+ *                   windowSize = GreatestCommonDivisor(checkpointInterval, duration, period)
+ * @param windowNum defined by Window(duration, period), windowNum = duration / windowSize
+ * @param windowStride defined by Window(duration, period), windowStride = duration / windowSize
+ */
+class WindowManager(windowSize: Long, windowNum: Long, windowStride: Long) extends ClockListener {
+  // startTime of the earliest window
+  private var startTime: Option[TimeStamp] = None
+  // endTime of the latest window
+  private var endTime: Option[TimeStamp] = None
+
+  def this(windowSize: Long, windowNum: Long) = this(windowSize, windowNum, windowNum)
+
+  def this(windowSize: Long) = this(windowSize, 1)
+
+  override def syncTime(timestamp: TimeStamp): Unit = {
+    super.syncTime(timestamp)
+    if (startTime.isEmpty) {
+      startTime = Some(CheckpointWindow.at(timestamp, windowSize).startTime)
+      endTime = startTime.map(_ + windowSize * windowNum)
+    }
+  }
+
+  def shouldForward: Boolean = {
+    endTime.exists(_ <= getTime)
+  }
+
+  /**
+   * forward by one windowStride
+   */
+  def forward(): Unit = {
+    startTime = startTime.map(_ + windowSize * windowStride)
+    endTime = endTime.map(_ + windowSize * windowStride)
+  }
+
+  /**
+   * forward to contain the timestamp
+   * @param timestamp
+   */
+  def forwardTo(timestamp: TimeStamp): Unit = {
+    if (endTime.nonEmpty) {
+      while (endTime.get <= timestamp) {
+        forward()
+      }
+    }
+  }
+
+  /**
+   * get all the managed windows
+   * @return
+   */
+  def getWindows: Array[CheckpointWindow] = {
+    if (startTime.nonEmpty && endTime.nonEmpty) {
+      (for {
+        time <- startTime.get until endTime.get by windowSize
+      } yield CheckpointWindow(time, time + windowSize)).toArray
+    } else {
+      Array.empty[CheckpointWindow]
+    }
+  }
+
+  /**
+   * get a merged large window of all the managed windows
+   * @return
+   */
+  def getMergedWindow: Option[CheckpointWindow] = {
+    startTime.flatMap(st => endTime.map(et => CheckpointWindow(st, et)))
+  }
+
+  def getWindowSize = windowSize
+
+}
+

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/impl/DefaultCheckpointManager.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/impl/DefaultCheckpointManager.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.impl
+
+import org.apache.gearpump.TimeStamp
+import org.apache.gearpump.streaming.state.internal.api.{CheckpointStore, CheckpointManager}
+import org.apache.gearpump.util.LogUtil
+import org.slf4j.Logger
+
+object DefaultCheckpointManager {
+  private val LOG: Logger = LogUtil.getLogger(classOf[DefaultCheckpointManager])
+}
+
+/**
+ * default implementation for CheckpointManager
+ */
+class DefaultCheckpointManager(val checkpointStore: CheckpointStore,
+                               private var checkpointInterval: Long = 0L) extends CheckpointManager {
+  import org.apache.gearpump.streaming.state.internal.impl.DefaultCheckpointManager._
+
+  private var checkpointTime: Option[Long] = None
+
+  /**
+   * checkpointInterval change will affect checkpointTime
+   * after next checkpoint
+   * @param interval
+   */
+  override def setCheckpointInterval(interval: Long): Unit = {
+    this.checkpointInterval = interval
+  }
+
+  override def getCheckpointInterval: Long = this.checkpointInterval
+
+  override def syncTime(timestamp: TimeStamp): Unit = {
+    super.syncTime(timestamp)
+    if (checkpointTime.isEmpty) {
+      checkpointTime = Some(getTime + checkpointInterval)
+    }
+  }
+
+  override def shouldCheckpoint: Boolean = {
+    checkpointTime.nonEmpty && getTime >= checkpointTime.get
+  }
+
+  override def recover(timestamp: TimeStamp): Option[Array[Byte]] = {
+    checkpointStore.read(timestamp)
+  }
+
+  override def checkpoint(timestamp: TimeStamp, data: Array[Byte]): Unit = {
+    checkpointStore.write(timestamp, data)
+    checkpointTime = checkpointTime.map(_ + checkpointInterval)
+  }
+
+  override def getCheckpointTime: Option[TimeStamp] = checkpointTime
+
+  override def close(): Unit = {
+    checkpointStore.close()
+  }
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/impl/DefaultStateManager.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/impl/DefaultStateManager.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.impl
+
+import org.apache.gearpump._
+import org.apache.gearpump.streaming.state.api.MonoidState
+import org.apache.gearpump.streaming.state.internal.api.{CheckpointWindow, ClockListener, CheckpointManager, StateManager}
+import org.apache.gearpump.streaming.task.TaskContext
+import org.apache.gearpump.util.LogUtil
+import org.slf4j.Logger
+
+import scala.collection.immutable.TreeMap
+
+object DefaultStateManager {
+  private val LOG: Logger = LogUtil.getLogger(classOf[DefaultStateManager[_]])
+}
+
+/**
+ * manage states for non-window applications
+ */
+class DefaultStateManager[T](val state: MonoidState[T],
+                             val checkpointWindowSize: Long,
+                             val checkpointManager: CheckpointManager,
+                             taskContext: TaskContext) extends StateManager[T] {
+  import org.apache.gearpump.streaming.state.internal.impl.DefaultStateManager._
+
+  private var value: T = state.init
+
+  override val clockListeners: Array[ClockListener] = Array(checkpointManager)
+
+  override def init(timestamp: TimeStamp): Unit = {
+    super.init(timestamp)
+    checkpointManager.recover(timestamp) match {
+      case Some(bytes) => 
+        value = state.deserialize(bytes)
+        LOG.info(s"recovered $value at $timestamp")
+      case None => LOG.warn(s"checkpoint at $timestamp not found")
+    }
+  }
+
+  /**
+   * 1. checkpoint states
+   * 2. aggregate checkpointed states to value and send it down streams
+   * 3. drop all the expired states
+   * @param states
+   */
+  override def checkpoint(states: TreeMap[CheckpointWindow, T]): Unit = {
+    states.foreach { case (win, st) =>
+      value = state.update(value, st)
+      checkpointManager.checkpoint(win.endTime, state.serialize(value))
+      LOG.info(s"checkpoint (${win.endTime}, $value) at ${win.endTime}")
+      taskContext.output(Message(state.serialize(value), win.endTime))
+    }
+    states.lastOption.foreach { case (win, _) =>
+      dropStatesBefore(win.endTime)
+    }
+  }
+
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/impl/HadoopCheckpointStore.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/impl/HadoopCheckpointStore.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.impl
+
+import org.apache.gearpump.TimeStamp
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.state.internal.api.{CheckpointStoreFactory, CheckpointStore}
+import org.apache.gearpump.streaming.state.util.StateConfig
+import org.apache.gearpump.streaming.task.{TaskContext, TaskId}
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.hadoop.fs.permission.{FsAction, FsPermission}
+import org.apache.hadoop.io.{BytesWritable, LongWritable, SequenceFile}
+import org.apache.hadoop.io.SequenceFile.{Writer, Reader}
+
+import scala.util.Try
+
+object HadoopCheckpointStore {
+  def apply(appId: Int, taskId: TaskId, conf: Configuration): HadoopCheckpointStore = {
+    val rootPath = new Path(ROOT_PATH)
+    val fs = rootPath.getFileSystem(conf)
+    if (!fs.exists(rootPath)) {
+      fs.mkdirs(rootPath, new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.ALL))
+    }
+    val filePath = new Path(FILE_PATH_FORMAT.format(ROOT_PATH, appId, taskId.processorId, taskId.index))
+    if (!fs.exists(filePath)) {
+      fs.create(filePath)
+    }
+
+    val writer = SequenceFile.createWriter(conf, Writer.file(filePath),
+      Writer.keyClass(classOf[LongWritable]), Writer.valueClass(classOf[BytesWritable]))
+    val getReader = () => new SequenceFile.Reader(conf, Reader.file(filePath))
+    new HadoopCheckpointStore(writer, getReader())
+  }
+
+  val ROOT_PATH = "gearpump"
+  val FILE_PATH_FORMAT = Array("%s", "app%d", "task_%d_%d").mkString(Path.SEPARATOR)
+
+}
+
+/**
+ * checkpoint store that writes to Hadoop dfs (e.g. HDFS)
+ */
+class HadoopCheckpointStore(writer: Writer,
+                            getReader: => Reader) extends CheckpointStore {
+
+  override def write(timestamp: TimeStamp, checkpoint: Array[Byte]): Unit = {
+    writer.append(new LongWritable(timestamp), new BytesWritable(checkpoint))
+    writer.hflush()
+  }
+
+  override def read(timestamp: TimeStamp): Option[Array[Byte]] = {
+    val reader = Try(getReader).toOption
+    reader.flatMap { r =>
+      val key = new LongWritable
+      val value = new BytesWritable
+
+      @annotation.tailrec
+      def readAux(checkpoint: Option[Array[Byte]]): Option[Array[Byte]] = {
+        if (r.next(key, value)) {
+          if (key.get == timestamp) {
+            readAux(Option(value.copyBytes))
+          } else {
+            readAux(checkpoint)
+          }
+        } else {
+          checkpoint
+        }
+      }
+
+      try {
+        readAux(None)
+      } finally {
+        r.close()
+      }
+    }
+  }
+
+  override def close(): Unit = {
+    writer.close()
+  }
+}
+
+class HadoopCheckpointStoreFactory extends CheckpointStoreFactory {
+  override def getCheckpointStore(conf: UserConfig, taskContext: TaskContext): CheckpointStore = {
+    import taskContext.{appId, taskId}
+
+    val stateConfig = new StateConfig(conf)
+    val configuration = new Configuration()
+    configuration.set("fs.defaultFS", stateConfig.getHDFS)
+    HadoopCheckpointStore(appId, taskId, configuration)
+  }
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/impl/InMemoryCheckpointStore.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/impl/InMemoryCheckpointStore.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.impl
+
+import org.apache.gearpump.TimeStamp
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.state.internal.api.{CheckpointStoreFactory, CheckpointStore}
+import org.apache.gearpump.streaming.task.TaskContext
+
+/**
+ * an in memory store provided for test
+ * should not be used in real cases
+ */
+class InMemoryCheckpointStore extends CheckpointStore {
+  private var checkpoints = Map.empty[TimeStamp, Array[Byte]]
+
+  override def write(timestamp: TimeStamp, checkpoint: Array[Byte]): Unit = {
+    checkpoints += timestamp -> checkpoint
+  }
+
+  override def read(timestamp: TimeStamp): Option[Array[Byte]] = {
+    checkpoints.get(timestamp)
+  }
+
+  override def close(): Unit = {
+  }
+
+}
+
+class InMemoryCheckpointStoreFactory extends CheckpointStoreFactory {
+  override def getCheckpointStore(conf: UserConfig, taskContext: TaskContext): CheckpointStore = {
+    new InMemoryCheckpointStore
+  }
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/impl/WindowStateManager.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/internal/impl/WindowStateManager.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding cstateyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a cstatey of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.impl
+
+import org.apache.gearpump._
+import org.apache.gearpump.streaming.state.internal.api._
+import org.apache.gearpump.streaming.state.api.MonoidState
+import org.apache.gearpump.streaming.task.TaskContext
+import org.apache.gearpump.util.LogUtil
+import org.slf4j.Logger
+
+import scala.collection.immutable.TreeMap
+
+object WindowStateManager {
+  val LOG: Logger = LogUtil.getLogger(classOf[WindowStateManager[_]])
+}
+
+/**
+ * manage states for window applications
+ */
+class WindowStateManager[T](val state: MonoidState[T],
+                            val checkpointWindowSize: Long,
+                            val checkpointManager: CheckpointManager,
+                            windowManager: WindowManager,
+                            taskContext: TaskContext) extends StateManager[T] {
+
+  import org.apache.gearpump.streaming.state.internal.impl.WindowStateManager._
+
+  override val clockListeners: Array[ClockListener] = Array(checkpointManager, windowManager)
+
+  override def init(timestamp: TimeStamp): Unit = {
+    super.init(timestamp)
+    windowManager.forwardTo(timestamp)
+    windowManager.getWindows.foreach { window =>
+      checkpointManager.recover(window.endTime).map(state.deserialize) match {
+        case Some(st) => states += window -> st
+        case None => states += window -> state.init
+      }
+    }
+  }
+
+  /**
+   * 1. checkpoint states
+   * 2. merge states in a window if the window should forward
+   * 3. forward window
+   * 4. drop states expired by the window
+   */
+  override def checkpoint(states: TreeMap[CheckpointWindow, T]): Unit = {
+    states.foreach { case (win, st) =>
+      checkpointManager.checkpoint(win.endTime, state.serialize(st))
+      LOG.info(s"checkpoint (${win.endTime}, $st) at ${win.endTime}")
+    }
+    if (windowManager.shouldForward) {
+      windowManager.getMergedWindow.foreach { win =>
+        merge(win).foreach { case (mergedWin, mergedState) =>
+          LOG.info(s"merged window $mergedWin; merged state $mergedState")
+          taskContext.output(Message(state.serialize(mergedState), mergedWin.endTime))
+        }
+
+      }
+      windowManager.forward()
+      windowManager.getMergedWindow.foreach { win =>
+        dropStatesBefore(win.startTime)
+      }
+    }
+  }
+
+  private[impl] def merge(window: CheckpointWindow): Option[(CheckpointWindow, T)] = {
+    import org.apache.gearpump.streaming.state.internal.api.CheckpointWindow._
+    val startTime = window.startTime
+    val endTime = window.endTime
+    val statesToMerge = states
+      .dropWhile(_._1.endTime <= startTime)
+      .takeWhile(_._1.endTime <= endTime)
+    if (statesToMerge.isEmpty) {
+      None
+    } else {
+      val merged = statesToMerge.reduce { (left, right) =>
+
+        val (leftWindow, leftState) = left
+        val (rightWindow, rightState) = right
+        windowSemigroup.plus(leftWindow, rightWindow) -> state.update(leftState, rightState)
+      }
+      Some(merged)
+    }
+  }
+}

--- a/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/util/StateConfig.scala
+++ b/experiments/state/src/main/scala/org/apache/gearpump/streaming/state/util/StateConfig.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.util
+
+import akka.actor.ActorSystem
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.state.api.Window
+import org.apache.gearpump.streaming.state.internal.api.CheckpointStoreFactory
+
+object StateConfig {
+  val CHECKPOINT_STORE_FACTORY = "state.checkpoint.store.factory"
+  val CHECKPOINT_INTERVAL_DEFAULT = "state.checkpoint.interval.default"
+  val WINDOW = "state.window"
+  val HDFS_FS = "state.hdfs.fs"
+}
+
+class StateConfig(conf: UserConfig) {
+  import org.apache.gearpump.streaming.state.util.StateConfig._
+
+  def getLong(key: String): Long = {
+    conf.getLong(key).getOrElse(throw new RuntimeException(s"$key not configured"))
+  }
+
+  def getString(key: String): String = {
+    conf.getString(key).getOrElse(throw new RuntimeException(s"$key not configured"))
+  }
+
+  def getCheckpointStoreFactory: CheckpointStoreFactory = {
+    Class.forName(getString(CHECKPOINT_STORE_FACTORY)).newInstance()
+      .asInstanceOf[CheckpointStoreFactory]
+  }
+
+  def getCheckpointInterval(implicit system: ActorSystem): Long = {
+    val defaultInterval = getLong(CHECKPOINT_INTERVAL_DEFAULT)
+    getWindow match {
+      case None => defaultInterval
+      case Some(Window(duration, period)) =>
+        gcd(gcd(duration.toMillis, period.toMillis), defaultInterval)
+    }
+  }
+
+  def getWindow(implicit system: ActorSystem): Option[Window] = {
+    conf.getValue[Window](WINDOW)
+  }
+
+  def getHDFS: String = {
+    getString(HDFS_FS)
+  }
+
+  /**
+   * get greatest common divisor
+   */
+  @annotation.tailrec
+  private def gcd(left: Long, right: Long): Long = {
+    if (left < right) gcd(right, left)
+    else if (right == 0) left
+    else gcd(right, left % right)
+  }
+
+}

--- a/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/MessageCountSpec.scala
+++ b/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/MessageCountSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example
+
+import org.apache.gearpump.cluster.ClientToMaster.SubmitApplication
+import org.apache.gearpump.cluster.MasterToClient.SubmitApplicationResult
+import org.apache.gearpump.cluster.{TestUtil, MasterHarness}
+import org.apache.gearpump.util.Util
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{PropSpec, Matchers, BeforeAndAfter}
+
+import scala.util.Success
+
+class MessageCountSpec extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
+
+  before {
+    startActorSystem()
+  }
+
+  after {
+    shutdownActorSystem()
+  }
+
+  override def config = TestUtil.DEFAULT_CONFIG
+
+  property("MessageCount should succeed to submit application with required arguments") {
+    val requiredArgs = Array.empty[String]
+    val optionalArgs = Array(
+      "-gen", "2",
+      "-count", "2"
+    )
+
+    val args = {
+      Table(
+        ("requiredArgs", "optionalArgs"),
+        (requiredArgs, optionalArgs.take(0)),
+        (requiredArgs, optionalArgs.take(2)),
+        (requiredArgs, optionalArgs)
+      )
+    }
+    val masterReceiver = createMockMaster()
+    forAll(args) { (requiredArgs: Array[String], optionalArgs: Array[String]) =>
+      val args = requiredArgs ++ optionalArgs
+
+      val process = Util.startProcess(getMasterListOption(), getContextClassPath,
+        getMainClassName(MessageCount), args)
+      masterReceiver.expectMsgType[SubmitApplication](PROCESS_BOOT_TIME)
+      masterReceiver.reply(SubmitApplicationResult(Success(0)))
+
+      process.destroy()
+    }
+  }
+
+
+}

--- a/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/WindowAverageSpec.scala
+++ b/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/WindowAverageSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example
+
+import com.typesafe.config.Config
+import org.apache.gearpump.cluster.ClientToMaster.SubmitApplication
+import org.apache.gearpump.cluster.MasterToClient.SubmitApplicationResult
+import org.apache.gearpump.cluster.{TestUtil, MasterHarness}
+import org.apache.gearpump.util.Util
+import org.scalatest.{BeforeAndAfter, Matchers, PropSpec}
+import org.scalatest.prop.PropertyChecks
+
+import scala.util.Success
+
+class WindowAverageSpec extends PropSpec with PropertyChecks with Matchers with BeforeAndAfter with MasterHarness {
+  before {
+    startActorSystem()
+  }
+
+  after {
+    shutdownActorSystem()
+  }
+
+  override def config = TestUtil.DEFAULT_CONFIG
+
+  property("WindowAverage should succeed to submit application with required arguments") {
+    val requiredArgs = Array.empty[String]
+    val optionalArgs = Array(
+      "-gen", "2",
+      "-count", "2",
+      "-window", "2"
+    )
+
+    val args = {
+      Table(
+        ("requiredArgs", "optionalArgs"),
+        (requiredArgs, optionalArgs.take(0)),
+        (requiredArgs, optionalArgs.take(2)),
+        (requiredArgs, optionalArgs)
+      )
+    }
+    val masterReceiver = createMockMaster()
+    forAll(args) { (requiredArgs: Array[String], optionalArgs: Array[String]) =>
+      val args = requiredArgs ++ optionalArgs
+
+      val process = Util.startProcess(getMasterListOption(), getContextClassPath,
+        getMainClassName(WindowAverage), args)
+      masterReceiver.expectMsgType[SubmitApplication](PROCESS_BOOT_TIME)
+      masterReceiver.reply(SubmitApplicationResult(Success(0)))
+
+      process.destroy()
+    }
+  }
+}

--- a/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/processor/CountProcessorSpec.scala
+++ b/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/processor/CountProcessorSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example.processor
+
+import akka.actor.ActorSystem
+import org.apache.gearpump.Message
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.MockUtil
+import org.apache.gearpump.streaming.state.internal.impl.{InMemoryCheckpointStoreFactory, InMemoryCheckpointStore, DefaultCheckpointManager}
+import org.apache.gearpump.streaming.state.util.StateConfig
+import org.apache.gearpump.streaming.task.StartTime
+import org.mockito.Mockito._
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{PropSpec, Matchers}
+
+class CountProcessorSpec extends PropSpec with PropertyChecks with Matchers {
+
+  property("CountProcessor should update state clock") {
+
+    val taskContext = MockUtil.mockTaskContext
+
+    implicit val system = ActorSystem("test")
+
+    val longGen = Gen.chooseNum[Long](1, 1000)
+    forAll(longGen, longGen) {
+      (upstreamMinClock: Long, checkpointInterval: Long) =>
+
+        when(taskContext.upstreamMinClock).thenReturn(0L, upstreamMinClock)
+
+
+
+        val conf = UserConfig.empty
+          .withLong(StateConfig.CHECKPOINT_INTERVAL_DEFAULT, checkpointInterval)
+          .withString(StateConfig.CHECKPOINT_STORE_FACTORY,
+            classOf[InMemoryCheckpointStoreFactory].getName)
+
+        val count = new CountProcessor(taskContext, conf)
+        count.onStart(StartTime(0L))
+        count.onNext(Message("", upstreamMinClock))
+        count.onNext(Message("", upstreamMinClock))
+        if (upstreamMinClock < checkpointInterval) {
+          count.stateClock shouldBe Some(0L)
+        } else {
+          count.stateClock shouldBe Some(checkpointInterval)
+        }
+
+        system.shutdown()
+    }
+  }
+}

--- a/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/processor/GenNumProcessorSpec.scala
+++ b/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/processor/GenNumProcessorSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example.processor
+
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+import org.apache.gearpump.Message
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.MockUtil
+import org.apache.gearpump.streaming.task.StartTime
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalatest.{WordSpec, Matchers}
+
+class GenNumProcessorSpec extends WordSpec with Matchers {
+  "GenNumProcessor" should {
+    "send random numbers" in {
+
+      val taskContext = MockUtil.mockTaskContext
+
+      implicit val system = ActorSystem("test")
+
+      val mockTaskActor = TestProbe()
+
+      //mock self ActorRef
+      when(taskContext.self).thenReturn(mockTaskActor.ref)
+
+      val conf = UserConfig.empty
+      val genNum = new GenNumProcessor(taskContext, conf)
+      genNum.onStart(StartTime(0))
+      mockTaskActor.expectMsgType[Message]
+
+
+      genNum.onNext(Message("next"))
+      verify(taskContext).output(any[Message])
+      //mockTaskActor.expectMsgType[Message]
+
+      system.shutdown()
+    }
+  }
+}

--- a/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/processor/WindowAverageProcessorSpec.scala
+++ b/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/processor/WindowAverageProcessorSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example.processor
+
+import akka.actor.ActorSystem
+import org.apache.gearpump.Message
+import org.apache.gearpump.cluster.UserConfig
+import org.apache.gearpump.streaming.MockUtil
+import org.apache.gearpump.streaming.state.api.Window
+import org.apache.gearpump.streaming.state.internal.impl.{InMemoryCheckpointStoreFactory, InMemoryCheckpointStore, DefaultCheckpointManager}
+import org.apache.gearpump.streaming.state.util.StateConfig
+import org.apache.gearpump.streaming.task.StartTime
+import org.mockito.Mockito._
+import org.scalacheck.Gen
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.prop.PropertyChecks
+
+import scala.concurrent.duration._
+
+class WindowAverageProcessorSpec extends PropSpec with PropertyChecks with Matchers {
+  property("WindowAverageProcessor should update state clock") {
+
+    val taskContext = MockUtil.mockTaskContext
+
+    implicit val system = ActorSystem("test")
+
+    val longGen = Gen.chooseNum[Long](1, 1000)
+    forAll(longGen) {
+      (windowSize: Long) =>
+        val upstreamMinClock = windowSize
+        val checkpointInterval = windowSize
+
+        when(taskContext.upstreamMinClock).thenReturn(0L, upstreamMinClock)
+
+        val conf = UserConfig.empty
+          .withLong(StateConfig.CHECKPOINT_INTERVAL_DEFAULT, checkpointInterval)
+          .withString(StateConfig.CHECKPOINT_STORE_FACTORY, classOf[InMemoryCheckpointStoreFactory].getName)
+          .withValue[Window](StateConfig.WINDOW, Window(windowSize.millis, windowSize.millis))
+
+        val windowAverage = new WindowAverageProcessor(taskContext, conf)
+        windowAverage.onStart(StartTime(0L))
+        windowAverage.onNext(Message("" + upstreamMinClock, windowSize - 1))
+        windowAverage.onNext(Message("" + upstreamMinClock, windowSize - 1))
+        windowAverage.stateClock shouldBe Some(checkpointInterval)
+
+        system.shutdown()
+    }
+  }
+}

--- a/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/state/CountStateSpec.scala
+++ b/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/state/CountStateSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example.state
+
+import org.scalacheck.Gen
+import org.scalatest.{PropSpec, Matchers}
+import org.scalatest.prop.PropertyChecks
+
+class CountStateSpec extends PropSpec with PropertyChecks with Matchers {
+
+  property("CountState init should be 0") {
+    val countState = new CountState
+    countState.init shouldBe 0L
+  }
+
+  val longGen = Gen.chooseNum[Long](1L, 1000L)
+  property("CountState update should add up state and data") {
+    forAll(longGen, longGen) { (state: Long, data: Long) =>
+      val countState = new CountState
+      countState.update(state, data) shouldBe state + data
+    }
+  }
+
+  property("CountState should deserialize back what has been serialized out") {
+    forAll(longGen) { (state: Long) =>
+      val countState = new CountState
+      countState.deserialize(countState.serialize(state)) shouldBe state
+    }
+  }
+}

--- a/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/state/WindowAverageStateSpec.scala
+++ b/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/example/state/WindowAverageStateSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.example.state
+
+import com.twitter.algebird.AveragedValue
+import org.scalacheck.Gen
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.prop.PropertyChecks
+
+class WindowAverageStateSpec extends PropSpec with PropertyChecks with Matchers {
+
+  property("WindowAverageState init should be 0") {
+    val windowAverageState = new WindowAverageState
+    windowAverageState.init shouldBe AveragedValue(0L, 0.0)
+  }
+
+  val countGen = Gen.chooseNum[Long](1L, 1000L)
+  val valueGen = Gen.chooseNum[Double](1.0, 1000.0)
+  val averagedValueGen = for {
+    count <- countGen
+    value <- valueGen
+  } yield AveragedValue(count, value)
+  property("WindowAverageState update should add up two average values") {
+    forAll(averagedValueGen, averagedValueGen) { (state: AveragedValue, data: AveragedValue) =>
+      val windowAverageState = new WindowAverageState
+      val newCount = state.count + data.count
+      val newValue=
+        (state.count * state.value + data.count * data.value) / (state.count + data.count)
+      val result = windowAverageState.update(state, data)
+      result.count shouldBe newCount
+      (result.value -  newValue).abs should (be < 0.00001)
+    }
+  }
+
+  property("WindowAverageState should deserialize back what has been serialized out") {
+    forAll(averagedValueGen) { (state: AveragedValue) =>
+      val windowAverageState = new WindowAverageState
+      windowAverageState.deserialize(windowAverageState.serialize(state)) shouldBe state
+    }
+  }
+}
+

--- a/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/internal/api/WindowManagerSpec.scala
+++ b/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/internal/api/WindowManagerSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.api
+
+import org.apache.gearpump.TimeStamp
+import org.scalacheck.Gen
+import org.scalatest.{PropSpec, Matchers}
+import org.scalatest.prop.PropertyChecks
+
+class WindowManagerSpec extends PropSpec with PropertyChecks with Matchers {
+
+  val timestampGen = Gen.chooseNum[Long](1L, 1000L)
+  val windowSizeGen = Gen.chooseNum[Long](1L, 1000L)
+  val windowNumGen = Gen.chooseNum[Long](1, 10)
+  val windowStrideGen = Gen.chooseNum[Long](1, 10)
+
+  property("WindowManager syncTime should init startTime and endTime") {
+    forAll(timestampGen, windowNumGen) { (timestamp: TimeStamp, windowNum: Long) =>
+      val windowSize = timestamp * 2
+      val windowManager = new WindowManager(windowSize, windowNum)
+      windowManager.getMergedWindow shouldBe None
+
+      windowManager.syncTime(timestamp)
+
+      windowManager.getTime shouldBe timestamp
+      windowManager.getMergedWindow shouldBe Some(CheckpointWindow(0L, windowSize * windowNum))
+    }
+  }
+
+  property("WindowManager should forward if endTime is exceeded") {
+    forAll(timestampGen) { (timestamp: TimeStamp) =>
+      val windowSize = timestamp * 2
+      val windowManager = new WindowManager(windowSize)
+      windowManager.shouldForward shouldBe false
+
+      windowManager.syncTime(timestamp)
+      windowManager.syncTime(windowSize)
+      windowManager.shouldForward shouldBe true
+    }
+  }
+
+  property("WindowManager should forward by defined stride") {
+    forAll(windowSizeGen, windowNumGen, windowStrideGen) {
+      (windowSize, windowNum, windowStride) =>
+        val windowManager = new WindowManager(windowSize, windowNum, windowStride)
+        windowManager.syncTime(0L)
+        windowManager.forward()
+        windowManager.getMergedWindow shouldBe
+          Some(CheckpointWindow(windowSize * windowStride, windowSize * (windowNum + windowStride)))
+    }
+  }
+
+  property("WindowManager should forward to a given timestamp") {
+    forAll(timestampGen, windowSizeGen, windowNumGen) {
+      (timestamp, windowSize, windowNum) =>
+        val windowManager = new WindowManager(windowSize, windowNum)
+        windowManager.syncTime(0L)
+        windowManager.forwardTo(timestamp)
+        val window = windowManager.getMergedWindow.getOrElse(fail("merged window not found"))
+        val startTime = window.startTime
+        val endTime = window.endTime
+        timestamp should (be >= startTime and be < endTime)
+    }
+  }
+
+  property("WindowManager should get all managed windows") {
+    forAll(windowSizeGen, windowNumGen, windowStrideGen) {
+      (windowSize: Long, windowNum: Long, windowStride: Long) =>
+        val windowManager = new WindowManager(windowSize, windowNum, windowStride)
+        windowManager.getWindows shouldBe empty
+        windowManager.syncTime(0L)
+        val expected = 0L.until(windowNum).map(i => CheckpointWindow(i * windowSize, i * windowSize + windowSize)).toArray
+        windowManager.getWindows shouldBe expected
+    }
+  }
+
+}

--- a/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/internal/impl/DefaultCheckpointManagerSpec.scala
+++ b/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/internal/impl/DefaultCheckpointManagerSpec.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.impl
+
+import com.twitter.bijection.Injection
+import org.apache.gearpump.TimeStamp
+import org.apache.gearpump.streaming.state.internal.api.CheckpointStore
+import org.mockito.Mockito._
+import org.scalacheck.Gen
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{PropSpec, Matchers}
+
+class DefaultCheckpointManagerSpec extends PropSpec with PropertyChecks with Matchers with MockitoSugar {
+
+  val longGen = Gen.chooseNum[Long](1, 1000)
+
+  property("DefaultCheckpointManager should checkpoint when timestamp exceeds nextCheckpointTime") {
+    forAll(longGen, longGen) { (interval: Long, timestamp: TimeStamp) =>
+      val checkpointStore = mock[CheckpointStore]
+      val checkpointManager = new DefaultCheckpointManager(checkpointStore, interval)
+
+      checkpointManager.getCheckpointTime shouldBe None
+      checkpointManager.syncTime(0L)
+      checkpointManager.syncTime(timestamp)
+      checkpointManager.shouldCheckpoint shouldBe timestamp >= interval
+    }
+  }
+
+  property("DefaultCheckpointManager checkpoint should write time -> checkpoint to store") {
+    forAll(longGen, longGen) { (timestamp: TimeStamp, data: Long) =>
+      val checkpointStore = mock[CheckpointStore]
+      val checkpointManager = new DefaultCheckpointManager(checkpointStore)
+      val bytes = Injection[Long, Array[Byte]](data)
+
+      checkpointManager.checkpoint(timestamp, bytes)
+      verify(checkpointStore).write(timestamp, bytes)
+    }
+  }
+
+  property("DefaultCheckpointManager recover should read checkpoint at a time from store") {
+    forAll(longGen, longGen) { (timestamp: TimeStamp, data: Long) =>
+      val checkpointStore = mock[CheckpointStore]
+      val checkpointManager = new DefaultCheckpointManager(checkpointStore)
+      val bytes = Injection[Long, Array[Byte]](data)
+
+      when(checkpointStore.read(timestamp)).thenReturn(Some(bytes))
+
+      checkpointManager.recover(timestamp) shouldBe Some(bytes)
+      verify(checkpointStore).read(timestamp)
+    }
+  }
+
+  property("DefaultCheckpointManager should close store") {
+    val checkpointStore = mock[CheckpointStore]
+    val checkpointManager = new DefaultCheckpointManager(checkpointStore)
+
+    checkpointManager.close()
+    verify(checkpointStore).close()
+  }
+
+  property("DefaultCheckpointManager should update nextCheckpointTime on each checkpoint") {
+    forAll(longGen, longGen, longGen) { (interval: Long, timestamp: TimeStamp, data: Long) =>
+      val checkpointStore = mock[CheckpointStore]
+      val checkpointManager = new DefaultCheckpointManager(checkpointStore, interval)
+      val bytes = Injection[Long, Array[Byte]](data)
+
+      doNothing().when(checkpointStore).write(timestamp, bytes)
+
+      checkpointManager.getCheckpointTime shouldBe None
+      checkpointManager.syncTime(0L)
+      checkpointManager.syncTime(timestamp)
+      checkpointManager.getCheckpointTime shouldBe Some(interval)
+      checkpointManager.checkpoint(timestamp, bytes)
+      checkpointManager.getCheckpointTime shouldBe Some(interval * 2)
+
+      checkpointManager.setCheckpointInterval(interval * 2)
+      checkpointManager.getCheckpointTime shouldBe Some(interval * 2)
+      checkpointManager.checkpoint(timestamp, bytes)
+      checkpointManager.getCheckpointTime shouldBe Some(interval * 4)
+    }
+  }
+}

--- a/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/internal/impl/HadoopCheckpointStoreSpec.scala
+++ b/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/internal/impl/HadoopCheckpointStoreSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.impl
+
+import org.apache.gearpump.TimeStamp
+import org.apache.hadoop.io.{BytesWritable, LongWritable, SequenceFile}
+import org.mockito.Matchers._
+import org.mockito.Mockito._
+import org.scalacheck.Gen
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.prop.PropertyChecks
+
+class HadoopCheckpointStoreSpec extends PropSpec with PropertyChecks with Matchers with MockitoSugar {
+
+  property("HadoopCheckpointStore write should append to file system") {
+    val timestampGen = Gen.chooseNum[Long](1, 1000)
+    val checkpointGen = Gen.alphaStr
+    forAll(timestampGen, checkpointGen) { (timestamp: TimeStamp, checkpoint: String) =>
+      val writer = mock[SequenceFile.Writer]
+      val reader = mock[SequenceFile.Reader]
+      val hadoopCheckpointStore = new HadoopCheckpointStore(writer, reader)
+      val bytes =checkpoint.getBytes
+      hadoopCheckpointStore.write(timestamp, bytes)
+
+      verify(writer).append(new LongWritable(timestamp), new BytesWritable(bytes))
+      verify(writer).hflush()
+      verifyZeroInteractions(reader)
+    }
+  }
+
+  property("HadoopCheckpointStore read should scan through file system") {
+    val timestampGen = Gen.chooseNum[Long](1, 1000)
+    val numGen = Gen.chooseNum[Int](1, 100)
+    forAll(timestampGen, numGen) { (timestamp: TimeStamp, num: Int) =>
+      val writer = mock[SequenceFile.Writer]
+      val reader = mock[SequenceFile.Reader]
+      val hadoopCheckpointStore = new HadoopCheckpointStore(writer, reader)
+
+      val hasNexts = Array.fill(num - 1)(true) :+ false
+      when(reader.next(anyObject[LongWritable], anyObject[BytesWritable])).thenReturn(true, hasNexts:_*)
+
+      hadoopCheckpointStore.read(timestamp) shouldBe None
+
+      verify(reader, times(num + 1)).next(anyObject[LongWritable], anyObject[BytesWritable])
+      verify(reader).close()
+      verifyZeroInteractions(writer)
+    }
+  }
+
+}

--- a/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/internal/impl/InMemoryCheckpointStoreSpec.scala
+++ b/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/internal/impl/InMemoryCheckpointStoreSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.impl
+
+import com.twitter.bijection.Injection
+import org.scalacheck.Gen
+import org.scalatest.{PropSpec, Matchers}
+import org.scalatest.prop.PropertyChecks
+
+class InMemoryCheckpointStoreSpec extends PropSpec with PropertyChecks with Matchers {
+
+  property("InMemoryCheckpointStore should provide read / write checkpoint") {
+    val timestampGen = Gen.chooseNum[Long](1, 1000)
+    val checkpointGen = Gen.alphaStr.map(Injection[String, Array[Byte]])
+    forAll(timestampGen, checkpointGen) { (timestamp: Long, checkpoint: Array[Byte]) =>
+      val store = new InMemoryCheckpointStore
+      store.read(timestamp) shouldBe None
+      store.write(timestamp, checkpoint)
+      store.read(timestamp) shouldBe Some(checkpoint)
+    }
+  }
+}

--- a/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/internal/impl/WindowStateManagerSpec.scala
+++ b/experiments/state/src/test/scala/org/apache/gearpump/streaming/state/internal/impl/WindowStateManagerSpec.scala
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.gearpump.streaming.state.internal.impl
+
+import com.twitter.algebird.Monoid
+import com.twitter.algebird.Monoid._
+import com.twitter.bijection.Injection
+import com.twitter.bijection.Injection._
+import org.apache.gearpump.{Message, TimeStamp}
+import org.apache.gearpump.streaming.MockUtil
+import org.apache.gearpump.streaming.state.api.MonoidState
+import org.apache.gearpump.streaming.state.internal.api.{CheckpointWindow, WindowManager, CheckpointManager}
+import org.mockito.Mockito._
+import org.scalacheck.Gen
+import org.scalatest.{PropSpec, Matchers}
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.prop.PropertyChecks
+
+import scala.collection.immutable.TreeMap
+
+class WindowStateManagerSpec extends PropSpec with PropertyChecks with Matchers with MockitoSugar {
+  import org.apache.gearpump.streaming.state.internal.impl.WindowStateManagerSpec._
+
+  val timestampGen = Gen.chooseNum[Long](1L, 1000L)
+  val windowSizeGen = Gen.chooseNum[Long](1L, 1000L)
+  property("WindowStateManager init with no windows found for timestamp") {
+    forAll(timestampGen, windowSizeGen) { (timestamp: TimeStamp, windowSize: Long) =>
+      val checkpointManager = mock[CheckpointManager]
+      val windowManager = mock[WindowManager]
+      val taskContext = MockUtil.mockTaskContext
+      val stateManager = new WindowStateManager[Long](longState, windowSize, checkpointManager,
+        windowManager, taskContext)
+
+      when(windowManager.getWindows).thenReturn(Array.empty[CheckpointWindow])
+      stateManager.init(timestamp)
+
+      verify(windowManager).forwardTo(timestamp)
+      stateManager.minClock shouldBe timestamp
+      stateManager.getStates shouldBe empty
+    }
+  }
+
+  property("WindowStateManager init with no checkpoint found") {
+    forAll(timestampGen, windowSizeGen) { (timestamp: TimeStamp, windowSize: Long) =>
+      val checkpointManager = mock[CheckpointManager]
+      val windowManager = mock[WindowManager]
+      val taskContext = MockUtil.mockTaskContext
+      val window = CheckpointWindow(0L, timestamp)
+      val stateManager = new WindowStateManager[Long](longState, windowSize, checkpointManager,
+        windowManager, taskContext)
+
+      when(windowManager.getWindows).thenReturn(Array(window))
+      when(checkpointManager.recover(timestamp)).thenReturn(None)
+
+      stateManager.init(timestamp)
+
+      verify(windowManager).forwardTo(timestamp)
+      stateManager.minClock shouldBe timestamp
+      stateManager.getStates shouldBe TreeMap[CheckpointWindow, Long](window -> longState.init)
+    }
+  }
+
+  property("WindowStateManager init state to checkpoint at the timestamp") {
+    val stateGen = Gen.chooseNum[Long](0L, 1000L)
+    forAll(timestampGen, windowSizeGen, stateGen) { (timestamp: TimeStamp, windowSize: Long, state: Long) =>
+      val checkpointManager = mock[CheckpointManager]
+      val windowManager = mock[WindowManager]
+      val taskContext = MockUtil.mockTaskContext
+      val window = CheckpointWindow(0L, timestamp)
+      val stateManager = new WindowStateManager[Long](longState, windowSize, checkpointManager,
+        windowManager, taskContext)
+
+      when(windowManager.getWindows).thenReturn(Array(window))
+      when(checkpointManager.recover(timestamp)).thenReturn(Some(longState.serialize(state)))
+
+      stateManager.init(timestamp)
+
+      verify(windowManager).forwardTo(timestamp)
+      stateManager.minClock shouldBe timestamp
+      stateManager.getStates shouldBe TreeMap[CheckpointWindow, Long](window -> state)
+    }
+  }
+
+  val dataGen = Gen.chooseNum[Long](0L, 1000L)
+  val msgDecoder = (message: Message) => {
+    message.msg.asInstanceOf[String].toLong
+  }
+
+
+  property("WindowStateManager update state with no checkpoint or no window forward") {
+    forAll(dataGen, timestampGen, timestampGen) {
+      (data: Long, timestamp: TimeStamp, upstreamMinClock: TimeStamp) =>
+        val message = Message(data + "", timestamp)
+        val checkpointManager = mock[CheckpointManager]
+        val windowSize = timestamp * 2
+        val windowManager = mock[WindowManager]
+        val taskContext = MockUtil.mockTaskContext
+        val stateManager = new WindowStateManager[Long](longState, windowSize, checkpointManager,
+          windowManager, taskContext)
+
+        when(checkpointManager.shouldCheckpoint).thenReturn(false, false)
+        when(windowManager.shouldForward).thenReturn(false, false)
+        when(windowManager.getWindowSize).thenReturn(windowSize, windowSize)
+
+        stateManager.update(message, msgDecoder, upstreamMinClock)
+
+        val updatedState = longState.update(longState.init, data)
+        stateManager.getStates shouldBe TreeMap(CheckpointWindow(0L, windowSize) -> updatedState)
+
+        stateManager.update(message, msgDecoder, upstreamMinClock)
+
+        verify(checkpointManager, times(2)).syncTime(upstreamMinClock)
+        stateManager.getStates shouldBe TreeMap(CheckpointWindow(0L, windowSize) ->
+          longState.update(updatedState, data))
+    }
+  }
+
+  property("WindowStateManager update state with checkpoint and window forward") {
+    forAll(dataGen, timestampGen) {
+      (data: Long, timestamp: TimeStamp) =>
+        val message = Message(data + "", timestamp)
+        val checkpointManager = mock[CheckpointManager]
+        val windowSize = timestamp * 2
+        val windowManager = mock[WindowManager]
+        val taskContext = MockUtil.mockTaskContext
+        val stateManager = new WindowStateManager[Long](longState, windowSize, checkpointManager,
+          windowManager, taskContext)
+        val upstreamMinClock = windowSize
+        val checkpointTime = windowSize
+
+        when(checkpointManager.shouldCheckpoint).thenReturn(true)
+        when(checkpointManager.getCheckpointTime).thenReturn(Some(checkpointTime))
+        when(windowManager.shouldForward).thenReturn(true)
+        when(windowManager.getWindowSize).thenReturn(windowSize)
+        when(windowManager.getMergedWindow).thenReturn(Some(CheckpointWindow(0L, windowSize)), Some(CheckpointWindow(windowSize, windowSize * 2)))
+
+        stateManager.update(message, msgDecoder, upstreamMinClock)
+
+        val updatedState = longState.update(longState.init, data)
+        stateManager.minClock shouldBe checkpointTime
+        stateManager.getStates shouldBe empty
+        verify(checkpointManager).syncTime(upstreamMinClock)
+        verify(checkpointManager).checkpoint(windowSize, longState.serialize(updatedState))
+        verify(taskContext).output(MockUtil.argMatch((msg: Message) => {
+          msg.timestamp == windowSize
+        }))
+        verify(windowManager).forward()
+    }
+  }
+
+}
+
+object WindowStateManagerSpec {
+
+  val longState = new MonoidState[Long] {
+    override def monoid: Monoid[Long] = longMonoid
+
+    override def injection: Injection[Long, Array[Byte]] = long2BigEndian
+  }
+}


### PR DESCRIPTION
### This is not ready for merge but to gather comments as transaction api is a critical feature

There are a lot of changes so let me break down here to help review

Only two modifications are made to core

1. expose `upstreamMinClock` through `TaskContext` which is to decide when to checkpoint state 
2. add `withLong` and `getLong` to configure long value in user config

The rest is self contained in a new module `gearpump-experiment-state` under experiment. Half of them are UTs while the others are

1. API (`org.apache.gearpump.streaming.state.api`)

  * State
  * StateOp
  * Window
  * CheckpointManager
  * CheckpointStore

   I've added comments in each api. In brief, `State` is what user will use to manage states. Users could manipulate state by extending `StateOp`,  `State` is periodically checkpointed to a `CheckpointStore`, which is managed by a `CheckpointManager`. `Window` is defined for window function usages. 

2. Implementations (`org.apache.gearpump.streaming.state.impl`)

  Two state implementations are provided now (a SlidingWindowState will be added later)
  
     * DefaultState
     * FixedWindowState
   
  There is no need for users to write their own state management logic.

  A `DefaultCheckpointManager` is implemented. It maintains an internal checkpoint time, which decides when to checkpoint, and a pluggable `CheckpointStore`. 

  Only `InMemoryCheckpointStore` is available now and I'm working on a `HadoopStore`. 

3. Examples (`org.apache.gearpump.streaming.state.example`)

  There are two examples now.

    1. MessageCount

       a simple example to show how to use `DefaultState` to count the number of messages  received in all time.

    2.  WindowAverage

      a window application to show the usage of `FixedWindowState` to calculate the average of number received in each window.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/837)
<!-- Reviewable:end -->
