### PR TITLE
fix #890: add cloudera manager integration support for gearpump

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -17,7 +17,7 @@
 #
 
 # The logger for all GearPump daemon processes (including master, worker, local)
-gearpump.root.logger=INFO,DRFA
+gearpump.root.logger=INFO,RFA
 # The log directory for all daemon processes.
 # It will be overwritten by GearPump using value from entry log.daemon.dir in gear.conf.
 gearpump.log.dir=logs
@@ -65,21 +65,23 @@ log4j.appender.DRFA.File=${gearpump.log.dir}/${gearpump.log.file}
 # Rollver at midnight
 log4j.appender.DRFA.DatePattern=.yyyy-MM-dd
 log4j.appender.DRFA.layout=org.apache.log4j.PatternLayout
-log4j.appender.DRFA.layout.ConversionPattern=[%p] [%d{MM/dd/yyyy HH:mm:ss.SSS}] [%c{1}] %m%n
+#log4j.appender.DRFA.layout.ConversionPattern=[%p] [%d{MM/dd/yyyy HH:mm:ss.SSS}] [%c{1}] %m%n
+log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c{1}: %m%n
 
 #
 # Rolling File Appender
 #
 log4j.appender.RFA=org.apache.log4j.RollingFileAppender
 log4j.appender.RFA.File=${gearpump.log.dir}/${gearpump.log.file}
-
-# Logfile size and and 30 backups
-log4j.appender.RFA.MaxFileSize=10MB
-log4j.appender.RFA.MaxBackupIndex=30
-#log4j.appender.RFA.layout=org.apache.log4j.PatternLayout
+log4j.appender.RFA.layout=org.apache.log4j.PatternLayout
+log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %p %c{1}: %m%n
 #log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} - %m%n
 #log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
 #log4j.appender.RFA.layout.ConversionPattern=[%p] [%d{MM/dd/yyyy HH:mm:ss.SSS}] [%c{1}] %m%n
+
+# Logfile size and and backups
+log4j.appender.RFA.MaxFileSize=200MB
+log4j.appender.RFA.MaxBackupIndex=10
 
 #
 # Hadoop Filesystem Rolling File Appender, similar to RFA but writing to Hadoop Filesystem instead of local disk.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -219,7 +219,8 @@ object Build extends sbt.Build {
         // The classpath should not be expanded. Otherwise, the classpath maybe too long.
         // On windows, it may report shell error "command line too long"
         packExpandedClasspath := false,
-        packExtraClasspath := new DefaultValueMap(Seq("${PROG_HOME}/conf", "${PROG_HOME}/dashboard", "/etc/hadoop/conf"))
+        packExtraClasspath := new DefaultValueMap(Seq("/etc/gearpump/conf", "${PROG_HOME}/conf",
+          "${PROG_HOME}/dashboard", "/etc/hadoop/conf", "/etc/hbase/conf"))
       )
   ).dependsOn(core, streaming, services, external_kafka, yarn,storm,dsl,pagerank,hbase)
 


### PR DESCRIPTION
This is the first part: gearpump change. The parcel build script will be moved out of gearpump as a standalone project in second part.