### PR TITLE
Revert "fix #1128, Use redirect to handle yarn web proxy"

### DIFF
--- a/experiments/yarn/src/main/scala/org/apache/gearpump/experiments/yarn/master/YarnApplicationMaster.scala
+++ b/experiments/yarn/src/main/scala/org/apache/gearpump/experiments/yarn/master/YarnApplicationMaster.scala
@@ -93,7 +93,7 @@ class YarnApplicationMaster(appConfig: AppConfig, yarnConf: YarnConfiguration,
   private val servicesPort = appConfig.getEnv(SERVICES_PORT).toInt
   private[master] val resourceManagerClient = context.actorOf(propsRMClient, "resourceManagerClient")
   private[master] val host = InetAddress.getLocalHost.getHostName
-  private[master] val trackingURL = "http://" + host + ":" + servicesPort + "/redirect"
+  private[master] val trackingURL = "http://" + host + ":" + servicesPort
   private[master] var servicesActor: Option[ActorRef] = None
 
   startWith(ConnectingToResourceManager, initializedClusterStats)

--- a/services/src/main/scala/org/apache/gearpump/services/StaticService.scala
+++ b/services/src/main/scala/org/apache/gearpump/services/StaticService.scala
@@ -23,11 +23,6 @@ import spray.http.StatusCodes
 import spray.routing.HttpService
 
 import java.util.jar.Manifest
-import spray.http.HttpHeader
-import spray.http.HttpResponse
-import spray.http.HttpHeaders.Host
-import spray.http.HttpEntity
-import spray.http.MediaTypes._
 
 trait StaticService extends HttpService {
 
@@ -44,41 +39,16 @@ trait StaticService extends HttpService {
     new Manifest(input)
   }
 
-  private def getHost: HttpHeader => Option[Host] = {
-    case h: Host => Some(h)
-    case x => None
-  }
-
   val staticRoute =
     pathEndOrSingleSlash {
       getFromResource("index.html")
     } ~
-    path("favicon.ico") {
-      complete(StatusCodes.NotFound)
-    } ~
-    path("redirect") {
-      headerValue(getHost) {host =>
-
-        respondWithMediaType(`text/html`) {
-          complete {
-            new HttpResponse(StatusCodes.OK, HttpEntity(
-              s"""
-                |  <html>
-                |  <title>Redirect to Gearpump Dashboard</title>
-                |  <body>
-                |    <script>window.location = "http://${host.host}:${host.port}"
-                |    </script>
-                |  </body>
-                |  </html>
-              """.stripMargin
-            ))
-          }
-        }
-      }
-    } ~
-    path(Rest) { path =>
-      getFromResource("%s" format path)
-    } ~
+      path("favicon.ico") {
+        complete(StatusCodes.NotFound)
+      } ~
+      path(Rest) { path =>
+        getFromResource("%s" format path)
+      } ~
     pathPrefix("webjars") {
       get {
         getFromResourceDirectory("META-INF/resources/webjars")


### PR DESCRIPTION
Reverts intel-hadoop/gearpump#1133

Does not work. I believe the YARN web console makes client calls within the server and sends them back to the browser via the proxy path in the UI. We will need to manually switch to ip of gearpump services UI 