### PR TITLE
fix #1191 change Kryo's instantiator strategy

### DIFF
--- a/core/src/main/scala/org/apache/gearpump/serializer/FastKryoSerializer.scala
+++ b/core/src/main/scala/org/apache/gearpump/serializer/FastKryoSerializer.scala
@@ -19,6 +19,7 @@
 package org.apache.gearpump.serializer
 
 import akka.actor.{ExtendedActorSystem}
+import com.esotericsoftware.kryo.Kryo.DefaultInstantiatorStrategy
 import com.romix.akka.serialization.kryo.{KryoSerializer}
 import org.apache.gearpump.serializer.FastKryoSerializer.KryoSerializationException
 import org.apache.gearpump.util.LogUtil
@@ -30,6 +31,7 @@ class FastKryoSerializer(system: ExtendedActorSystem) {
 
   private val kryoSerializer = new KryoSerializer(system).serializer
   private val kryo = kryoSerializer.kryo
+  kryo.setInstantiatorStrategy(new DefaultInstantiatorStrategy)
   private val kryoClazz = new GearpumpSerialization(config).customize(kryo)
 
 


### PR DESCRIPTION
The latest's Kryo also uses DefaultInstantiatorStrategy as Kryo's default instantiator strategy.  