### PR TITLE
Revert "fix #1210, fix kafka examples"

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -170,7 +170,7 @@ object Build extends sbt.Build {
      libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _),
      libraryDependencies ++= (
         if (scalaVersion.value.startsWith("2.10")) List("org.scalamacros" %% "quasiquotes" % "2.1.0-M5")
-        else List("org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.4")
+        else Nil
       )
   )
 
@@ -258,7 +258,7 @@ object Build extends sbt.Build {
           ("org.apache.kafka" %% "kafka" % kafkaVersion classifier("test")) % "test"
         )
       )
-  ) dependsOn (streaming % "provided", dsl % "provided")
+  ) dependsOn (streaming % "provided", dsl)
 
   lazy val examples_kafka = Project(
     id = "gearpump-examples-kafka",
@@ -273,7 +273,7 @@ object Build extends sbt.Build {
         ),
         target in assembly := baseDirectory.value.getParentFile.getParentFile / "target" / scalaVersionMajor
       )
-  ) dependsOn(streaming % "test->test; provided", external_kafka)
+  ) dependsOn(streaming % "test->test", streaming % "provided", external_kafka  % "test->test; provided")
 
   lazy val fsio = Project(
     id = "gearpump-examples-fsio",


### PR DESCRIPTION
Reverts intel-hadoop/gearpump#1219 as the scala-parser-combinators library depends on scala 2.11.6

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/intel-hadoop/gearpump/1220)
<!-- Reviewable:end -->
